### PR TITLE
feat: [Novel Updates]: Automatic List Tracking

### DIFF
--- a/src/plugins/english/novelupdates.ts
+++ b/src/plugins/english/novelupdates.ts
@@ -587,9 +587,6 @@ class NovelUpdates implements Plugin.PluginBase {
     const chapterId = chapterPath.split(',')[1];
     chapterPath = chapterPath.split(',')[0];
 
-    await fetchApi(
-      `${this.site}readinglist_update.php?rid=${chapterId}&sid=${novelId}&checked=yes`,
-    );
     const result = await fetchApi(this.site + chapterPath);
     const body = await result.text();
     const url = result.url;
@@ -801,6 +798,10 @@ class NovelUpdates implements Plugin.PluginBase {
         `href="${this.getLocation(result.url)}/`,
       );
     }
+
+    await fetchApi(
+      `${this.site}readinglist_update.php?rid=${chapterId}&sid=${novelId}&checked=yes`,
+    );
 
     return chapterText;
   }

--- a/src/plugins/english/novelupdates.ts
+++ b/src/plugins/english/novelupdates.ts
@@ -7,7 +7,7 @@ import { Plugin } from '@typings/plugin';
 class NovelUpdates implements Plugin.PluginBase {
   id = 'novelupdates';
   name = 'Novel Updates';
-  version = '0.7.1';
+  version = '0.8.0';
   icon = 'src/en/novelupdates/icon.png';
   customCSS = 'src/en/novelupdates/customCSS.css';
   site = 'https://www.novelupdates.com/';
@@ -159,10 +159,11 @@ class NovelUpdates implements Plugin.PluginBase {
       chapterName = chapterName.replace(/\b\w/g, l => l.toUpperCase()).trim();
       const chapterUrl =
         'https:' + loadedCheerio(el).find('a').first().next().attr('href');
+      const chapterId = chapterUrl.split('/').filter(Boolean).pop();
 
       chapter.push({
         name: chapterName,
-        path: chapterUrl.replace(this.site, ''),
+        path: `${chapterUrl.replace(this.site, '')},${chapterId},${novelId}`,
       });
     });
 
@@ -582,6 +583,13 @@ class NovelUpdates implements Plugin.PluginBase {
     let chapterContent = '';
     let chapterText = '';
 
+    const novelId = chapterPath.split(',')[2];
+    const chapterId = chapterPath.split(',')[1];
+    chapterPath = chapterPath.split(',')[0];
+
+    await fetchApi(
+      `${this.site}readinglist_update.php?rid=${chapterId}&sid=${novelId}&checked=yes`,
+    );
     const result = await fetchApi(this.site + chapterPath);
     const body = await result.text();
     const url = result.url;


### PR DESCRIPTION
- when you click a chapter, it gets automatically marked in Novel Updates as read
- since the path changes, all Novel Updates chapter entries need to be cleared and parsed again
- the path now includes the novelId and chapterId
- the path gets split into 3 parts later on: novelId, chapterId, chapterPath