### PR TITLE
ReadNovelFull: Return HTML when parsing the chapter

### DIFF
--- a/scripts/multisrc/readnovelfull/sources.json
+++ b/scripts/multisrc/readnovelfull/sources.json
@@ -2,6 +2,9 @@
   {
     "id": "readnovelfull",
     "sourceSite": "https://readnovelfull.com",
-    "sourceName": "ReadNovelFull"
+    "sourceName": "ReadNovelFull",
+    "options": {
+      "versionIncrements": 1
+    }
   }
 ]

--- a/scripts/multisrc/readnovelfull/template.ts
+++ b/scripts/multisrc/readnovelfull/template.ts
@@ -159,7 +159,7 @@ class ReadNovelFullPlugin implements Plugin.PluginBase {
   async parseChapter(chapterPath: string): Promise<string> {
     const $ = await this.getCheerio(this.site + chapterPath, false);
 
-    return $('#chr-content').text();
+    return $('#chr-content').html();
   }
 
   async searchNovels(


### PR DESCRIPTION
## Problem
I was reading [The Vampire System's Chapter 2](https://readnovelfull.com/my-vampire-system/chapter-2-daily-ques.html) and noticed that I was not seeing all the information, turns out the system messages were not being rendered correctly.

These system messages are of the format `< ....example text... >` with the usage of cheerio's `.text()` method the content of the system messages was being removed which means that we lose content of the chapter.

### Minimal reproducible script of the problem
```js
const sanitizeHtml = require("sanitize-html");
const cheerio = require("cheerio")

async function main() {
    const html = `<div id="chr-content"><br><p>&lt;User: Quinn Talen&gt;</p><br><p>&lt;Race: Human&gt;</p><br><p>&lt; Level 1&gt;</p><br><p>&lt;0/100 exp&gt;</p><br><p>&lt;HP 10/10&gt;</p></div>`
    const $ = cheerio.load(html);
    const chapter = $('#chr-content').text()

    let clean = sanitizeHtml(chapter, {
        allowedTags: sanitizeHtml.defaults.allowedTags.concat([
            'img',
            'i',
            'em',
            'b',
            'a',
            'div',
            'ol',
            'li',
            'title',
        ]),
        allowedAttributes: {
            'img': ['src', 'class', 'id'],
            'a': ['href', 'class', 'id'],
            'div': ['class', 'id'],
            'p': ['class', 'id'],
            'ol': ['reversed', 'start', 'type'],
        },
        allowedSchemes: ['data', 'http', 'https', 'file'],
    });
    console.log(clean)
}

main()
```

**Output:** 
```
&lt; Level 1&gt;&lt;0/100 exp&gt;
```

### Solution
I have replaced the `.text()` method with the `.html()` method which is the correct content to be fed to the sanitizer on the actual app.

**Output**: 
```html
<br />
<p>&lt;User: Quinn Talen&gt;</p><br />
<p>&lt;Race: Human&gt;</p><br />
<p>&lt; Level 1&gt;</p><br />
<p>&lt;0/100 exp&gt;</p><br />
<p>&lt;HP 10/10&gt;</p>
```