### PR TITLE
fix: Update MTL Novel source URLs

### DIFF
--- a/scripts/multisrc/mtlnovel/sources.json
+++ b/scripts/multisrc/mtlnovel/sources.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "mtlnovel",
-    "sourceSite": "https://www.mtlnovel.com/",
+    "sourceSite": "https://www.mtlnovels.com/",
     "sourceName": "MTL Novel",
     "options": {
       "lang": "English"
@@ -9,7 +9,7 @@
   },
   {
     "id": "mtlnovel-fr",
-    "sourceSite": "https://fr.mtlnovel.com/",
+    "sourceSite": "https://fr.mtlnovels.com/",
     "sourceName": "MTL Novel (FR)",
     "options": {
       "lang": "French"
@@ -17,7 +17,7 @@
   },
   {
     "id": "mtlnovel-es",
-    "sourceSite": "https://es.mtlnovel.com/",
+    "sourceSite": "https://es.mtlnovels.com/",
     "sourceName": "MTL Novel (ES)",
     "options": {
       "lang": "Spanish"
@@ -25,10 +25,26 @@
   },
   {
     "id": "mtlnovel-id",
-    "sourceSite": "https://id.mtlnovel.com/",
+    "sourceSite": "https://id.mtlnovels.com/",
     "sourceName": "MTL Novel (ID)",
     "options": {
       "lang": "Indonesian"
+    }
+  },
+  {
+    "id": "mtlnovel-pt",
+    "sourceSite": "https://pt.mtlnovels.com/",
+    "sourceName": "MTL Novel (PT)",
+    "options": {
+      "lang": "Portuguese"
+    }
+  },
+  {
+    "id": "mtlnovel-ru",
+    "sourceSite": "https://ru.mtlnovels.com/",
+    "sourceName": "MTL Novel (RU)",
+    "options": {
+      "lang": "Russian"
     }
   }
 ]

--- a/scripts/multisrc/mtlnovel/template.ts
+++ b/scripts/multisrc/mtlnovel/template.ts
@@ -32,8 +32,8 @@ class MTLNovelPlugin implements Plugin.PluginBase {
     this.name = metadata.sourceName;
     this.icon = 'multisrc/mtlnovel/mtlnovel/icon.png';
     this.site = metadata.sourceSite;
-    this.mainUrl = 'https://www.mtlnovel.com/';
-    this.version = '1.1.1';
+    this.mainUrl = 'https://www.mtlnovels.com/';
+    this.version = '1.1.2';
     this.options = metadata.options ?? ({} as MTLNovelOptions);
     this.filters = metadata.filters satisfies Filters;
   }
@@ -42,7 +42,7 @@ class MTLNovelPlugin implements Plugin.PluginBase {
     url: string,
     headers: Headers = new Headers(),
   ): Promise<Response> {
-    headers.append('Alt-Used', 'www.mtlnovel.com');
+    headers.append('Alt-Used', 'www.mtlnovels.com');
     const r = await fetchApi(url, { headers });
     if (!r.ok)
       throw new Error(
@@ -124,17 +124,23 @@ class MTLNovelPlugin implements Plugin.PluginBase {
         case 'Mots Clés':
         case 'Género':
         case 'Label':
+        case 'Gênero':
+        case 'Tag':
+        case 'Теги':
           if (novel.genres) novel.genres += ', ' + infoValue;
           else novel.genres = infoValue;
           break;
         case 'Author':
         case 'Auteur':
         case 'Autor(a)':
+        case 'Autor':
+        case 'Автор':
           novel.author = infoValue;
           break;
         case 'Status':
         case 'Statut':
         case 'Estado':
+        case 'Положение дел':
           if (infoValue == 'Hiatus') novel.status = NovelStatus.OnHiatus;
           else novel.status = infoValue;
           break;
@@ -169,6 +175,12 @@ class MTLNovelPlugin implements Plugin.PluginBase {
     };
 
     novel.chapters = await getChapters();
+
+    if (novel.genres) {
+      const genresArray = novel.genres.split(', ');
+      genresArray.pop();
+      novel.genres = genresArray.join(', ');
+    }
 
     return novel;
   }
@@ -219,7 +231,7 @@ class MTLNovelPlugin implements Plugin.PluginBase {
 
   imageRequestInit: Plugin.ImageRequestInit = {
     headers: {
-      'Alt-Used': 'www.mtlnovel.com',
+      'Alt-Used': 'www.mtlnovels.com',
     },
   };
 }


### PR DESCRIPTION
- Update source URLs for English, French, Spanish, and Indonesian versions of MTL Novel. (fix #1198)
- Add support for Portuguese and Russian versions of MTL Novel.
- fix genre having "see history" at the end