### PR TITLE
Fixed Boxnovel routing to novgo

### DIFF
--- a/scripts/multisrc/madara/sources.json
+++ b/scripts/multisrc/madara/sources.json
@@ -6,7 +6,7 @@
     "options": {
       "useNewChapterEndpoint": true,
       "customJs": "chapterText.find('p').first().next('div').remove()",
-      "versionIncrements": 3
+      "versionIncrements": 4
     }
   },
   {

--- a/scripts/multisrc/madara/sources.json
+++ b/scripts/multisrc/madara/sources.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "boxnovel",
-    "sourceSite": "https://boxnovel.com/",
+    "sourceSite": "https://novgo.co/",
     "sourceName": "BoxNovel",
     "options": {
       "useNewChapterEndpoint": true,


### PR DESCRIPTION
I fixed the issue of boxnovel.com pointing towards novgo.c,o by changing the URL of the boxnovel.com plugin to novgo.co.