### PR TITLE
fix: update novelbuddy summary css path to remove 'Show More'

### DIFF
--- a/src/plugins/english/novelbuddy.ts
+++ b/src/plugins/english/novelbuddy.ts
@@ -6,7 +6,7 @@ class NovelBuddy implements Plugin.PluginBase {
   id = 'novelbuddy';
   name = 'NovelBuddy.io';
   site = 'https://novelbuddy.io/';
-  version = '1.0.1';
+  version = '1.0.2';
   icon = 'src/en/novelbuddy/icon.png';
 
   parseNovels(loadedCheerio: CheerioAPI) {
@@ -51,7 +51,7 @@ class NovelBuddy implements Plugin.PluginBase {
       path: novelPath,
       name: loadedCheerio('.name h1').text().trim() || 'Untitled',
       cover: 'https:' + loadedCheerio('.img-cover img').attr('data-src'),
-      summary: loadedCheerio('.section-body.summary').text().trim(),
+      summary: loadedCheerio('.section-body.summary .content').text().trim(),
       chapters: [],
     };
 


### PR DESCRIPTION
Remove unecessary 'SHOW MORE' from NovelBuddy summary.

On novel buddy:
![image](https://github.com/user-attachments/assets/03099798-c98c-4b21-a718-bf66e771d88a)

before: 
![image](https://github.com/user-attachments/assets/741b688a-aa0e-4193-a1f7-7477c54313b7)
after: 
![image](https://github.com/user-attachments/assets/f84a3b15-368e-4dac-ab78-9a442b478eb9)
