### PR TITLE
fix: update faqwikius path without 'www.'

### DIFF
--- a/src/plugins/english/faqwikius.ts
+++ b/src/plugins/english/faqwikius.ts
@@ -6,8 +6,8 @@ import { NovelStatus } from '@libs/novelStatus';
 class FaqWikiUs implements Plugin.PluginBase {
   id = 'FWK.US';
   name = 'Faq Wiki';
-  site = 'https://www.faqwiki.us/';
-  version = '2.0.0';
+  site = 'https://faqwiki.us/';
+  version = '2.0.1';
   icon = 'src/en/faqwikius/icon.png';
 
   parseNovels(loadedCheerio: CheerioAPI, searchTerm?: string) {


### PR DESCRIPTION
### Issue
#1415

### Description 
Fix Faqwikius source having incorrect paths: all paths on the site do not have `www.` so when removing the site url with `?.replace(this.site, '')` nothing was happening. Fixed by removing `www.` from the site url.

![image](https://github.com/user-attachments/assets/9642ae76-a14c-4b81-861d-d0aec099273f)