### PR TITLE
fix(novelfull): add image fallbacks

### DIFF
--- a/src/plugins/english/novelfull.ts
+++ b/src/plugins/english/novelfull.ts
@@ -6,7 +6,7 @@ import { Filters, FilterTypes } from '@libs/filterInputs';
 class NovelFull implements Plugin.PluginBase {
   id = 'novelfull';
   name = 'NovelFull';
-  version = '1.0.1';
+  version = '1.0.2';
   icon = 'src/en/novelfull/icon.png';
   site = 'https://novelfull.com/';
 
@@ -16,8 +16,12 @@ class NovelFull implements Plugin.PluginBase {
     loadedCheerio('.col-truyen-main .list-truyen .row').each((idx, ele) => {
       const novelName = loadedCheerio(ele).find('h3.truyen-title > a').text();
 
-      const novelCover =
-        this.site + loadedCheerio(ele).find('img').attr('src')?.slice(1);
+      // Images from the site are now lazy loaded, so we need to check data-cfsrc as well
+      let novelCover =
+        loadedCheerio(ele).find('img').attr('src') ??
+        loadedCheerio(ele).find('img').attr('data-cfsrc');
+
+      novelCover = novelCover ? this.site + novelCover.slice(1) : undefined;
 
       const novelUrl = loadedCheerio(ele)
         .find('h3.truyen-title > a')
@@ -60,10 +64,19 @@ class NovelFull implements Plugin.PluginBase {
 
     let loadedCheerio = parseHTML(body);
 
+    // Images from the site are now lazy loaded, so we need to check data-cfsrc as well (and fallback to other locations)
+    let cover =
+      loadedCheerio('div.book > img').attr('src') ??
+      loadedCheerio('div.book > img').attr('data-cfsrc') ??
+      loadedCheerio('div.book > noscript > img').attr('src') ??
+      loadedCheerio('meta[name="image"]').attr('content');
+
+    cover = cover ? this.site + cover.slice(1) : undefined;
+
     const novel: Plugin.SourceNovel = {
       path: novelPath,
       name: loadedCheerio('div.book > img').attr('alt') || 'Untitled',
-      cover: this.site + loadedCheerio('div.book > img').attr('src'),
+      cover: cover,
       summary: loadedCheerio('div.desc-text').text().trim(),
       status: loadedCheerio('h3:contains("Status")').next().text(),
       chapters: [],


### PR DESCRIPTION
### Issue
#1180


### Description

* Fix NovelFull not loading images
  * Found that HTML we get in app is different than plugin test website slightly. Images are [lazy loaded by CloudFlare](https://stackoverflow.com/questions/21611614/what-is-data-cfsrc-in-html) so need to check for img src in different locations. 
  
<img src="https://github.com/user-attachments/assets/ab7505e3-a067-4f5f-9f7d-1d74a8d61c89" width="200"/>
<img src="https://github.com/user-attachments/assets/7d600cbd-35f2-419a-bce0-4c564cacf65d" width="200"/>
