### PR TITLE
Update issue template with plugin version

### DIFF
--- a/.github/ISSUE_TEMPLATE/report_issue.yml
+++ b/.github/ISSUE_TEMPLATE/report_issue.yml
@@ -305,7 +305,18 @@ body:
       description: |
         You can find your LNReader version in **More → About**.
       placeholder: |
-        Example: "1.1.19"
+        Example: "2.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin version
+      description: |
+        You can find your Plugin version in **Browse → Installed** and scrolling to the desired source.
+      placeholder: |
+        Example: "1.0.1"
     validations:
       required: true
 
@@ -316,7 +327,7 @@ body:
       description: |
         You can find this somewhere in your Android settings.
       placeholder: |
-        Example: "Android 11"
+        Example: "Android 15"
     validations:
       required: true
 
@@ -337,7 +348,7 @@ body:
           required: true
         - label: I have written a short but informative title.
           required: true
-        - label: I have updated the app to version **[1.1.19](https://github.com/LNReader/lnreader/releases/latest)**.
+        - label: I have updated the app to version **[2.0.0](https://github.com/LNReader/lnreader/releases/tag/v2.0.0-beta.3).** #(https://github.com/LNReader/lnreader/releases/latest)**.
           required: true
         - label: I have updated all installed extensions.
           required: true


### PR DESCRIPTION
Currently we don't ask for the plugin version by default in issues, and when checking issues days later, contributors are uncertain if anyone else has already addressed an issue. Asking for the specific version fixes this.

Also updated examples to more recent versions, and changed link to 2.0.0 version until a new "latest" is released.