### PR TITLE
StorySeeding fix - still broken

### DIFF
--- a/src/plugins/english/StorySeedling.ts
+++ b/src/plugins/english/StorySeedling.ts
@@ -129,25 +129,27 @@ class StorySeedlingPlugin implements Plugin.PluginBase {
           body: formData,
         })
           .then(r => r.json())
-          .catch(e => console.log('Chapter Parse Error: ' + e));
+          .catch(e => (novel.summary = novel.summary + '\n\n' + e));
 
-        results = results.data;
-        results.each(function (chap) {
-          if (chap.url == null) {
-            return;
-          }
-          const name = chap.title.text().trim();
-          const url = chap.url as string;
-          const releaseTime = chap.date.text().trim();
-          const chapterNumber = chap.slug;
+        if (results.data) {
+          results = results.data;
+          results.each(function (chap: any) {
+            if (chap.url == null) {
+              return;
+            }
+            const name = chap.title.text().trim();
+            const url = chap.url as string;
+            const releaseTime = chap.date.text().trim();
+            const chapterNumber = chap.slug;
 
-          chapters.push({
-            name: name,
-            path: url.replace(baseUrl, ''),
-            releaseTime,
-            chapterNumber: parseInt(chapterNumber),
+            chapters.push({
+              name: name,
+              path: url.replace(baseUrl, ''),
+              releaseTime,
+              chapterNumber: parseInt(chapterNumber),
+            });
           });
-        });
+        }
       }
     }
 

--- a/src/plugins/english/StorySeedling.ts
+++ b/src/plugins/english/StorySeedling.ts
@@ -129,7 +129,11 @@ class StorySeedlingPlugin implements Plugin.PluginBase {
           body: formData,
         })
           .then(r => r.json())
-          .catch(e => (novel.summary = novel.summary + '\n\n' + e));
+          .catch(
+            e =>
+              (novel.summary =
+                'Chapter Parse Error: ' + e + '\n\n' + novel.summary),
+          );
 
         if (results.data) {
           results = results.data;
@@ -159,11 +163,21 @@ class StorySeedlingPlugin implements Plugin.PluginBase {
   }
 
   async parseChapter(chapterPath: string): Promise<string> {
-    const body = await fetchApi(this.site + chapterPath).then(r => r.text());
+    const $ = await this.getCheerio(this.site + chapterPath, false);
 
-    const loadedCheerio = load(body);
-    const t = loadedCheerio('div.justify-center > div.mb-4');
-    const chapterText = t.html() || '';
+    const xdata = $('div[ax-load][x-data]').attr('x-data');
+
+    const t = $('div.justify-center > div.mb-4');
+    let chapterText = t.html() || '';
+
+    if (xdata) {
+      chapterText =
+        chapterText +
+        "\n\n Error parsing chapter: Turnstile detected. Advise just reading in web view until there's a fix.";
+      //   const listXdata = xdata?.split("'");
+      //   const dataNovelId = listXdata[1];
+      //   const dataNovelN = listXdata[3];
+    }
 
     return chapterText;
   }

--- a/src/plugins/english/StorySeedling.ts
+++ b/src/plugins/english/StorySeedling.ts
@@ -133,13 +133,13 @@ class StorySeedlingPlugin implements Plugin.PluginBase {
 
         if (results.data) {
           results = results.data;
-          results.each(function (chap: any) {
+          results.forEach(function (chap: any) {
             if (chap.url == null) {
               return;
             }
-            const name = chap.title.text().trim();
+            const name = chap.title;
             const url = chap.url as string;
-            const releaseTime = chap.date.text().trim();
+            const releaseTime = chap.date;
             const chapterNumber = chap.slug;
 
             chapters.push({


### PR DESCRIPTION
Fixed the parsing of chapters. Learned a good bit.
Added author detection.
Added book status detection.

Addresses #1649 

Turns out chapter content was broken too, can't fix that. Added a nice little error that won't ruin chapters if it suddenly fixes, and also will maybe disappear if they ever fix that.

Chapters have cloudflare turnstile on an ajax request then uses an "encoded" font.  Seems very extra. Doesn't appear to be possible to fix, but you can always read in webview and use the above fixes to be notified of updates?