### PR TITLE
Fix: Novelfire ToC Parsing

### DIFF
--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -90,7 +90,7 @@ class NovelFire implements Plugin.PluginBase {
   ): Promise<Plugin.ChapterItem[]> {
     const allChapters: Plugin.ChapterItem[] = [];
 
-    const url = `${this.site}/listChapterDataAjax?post_id=${post_id}`;
+    const url = `${this.site}listChapterDataAjax?post_id=${post_id}`;
     const result = await fetchApi(url);
     const body = await result.text();
 


### PR DESCRIPTION
Fixes #1924 
Probably, at least.

Issue:
Site now uses Ajax and loading directly gives a blank page.

Solution:
Switched to Ajax interface.
Removed rate limiting, chunking, and paging code as one response has all data from my testing.
Left code for detecting rate limiting, added code for detecting 404 on Ajax, in case issues return.

Tested fully in dev and on mobile.

Now that I can read again, I'm going back to bed.