### PR TITLE
Fix: Novelfire URL Parsing + Chapter Sorting

### DIFF
--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -107,7 +107,7 @@ class NovelFire implements Plugin.PluginBase {
     const json = JSON.parse(body);
     const chapters = json.data
       .map(index => {
-        const chapterName = index.title || index.slug;
+        const chapterName = load(index.title || index.slug).text();
         const chapterPath = `${novelPath}/chapter-${index.n_sort}`;
         const sortNumber = index.n_sort;
 


### PR DESCRIPTION
Fixes #1929

Issue:
Covers and Book URLs failed due to changing of formatting
Chapters sometimes in wrong order
Chapter names show encoded characters `&#039;` instead of `'`

Solution:
Added function to remove leading / to fix formatting
Added baseURL to coverURL to fix covers
Added chapter sort array
Decode characters