### PR TITLE
Fix: Allow testing paged novels

### DIFF
--- a/src/components/parse-novel.tsx
+++ b/src/components/parse-novel.tsx
@@ -403,8 +403,7 @@ export default function ParseNovelSection({
             </div>
 
             {/* Chapters Table */}
-            {(chapters.length > 0 ||
-              (sourceNovel.totalPages && sourceNovel.totalPages > 1)) && (
+            {(chapters.length > 0 || sourceNovel.totalPages) && (
               <div>
                 <div className="flex items-center justify-between mb-4">
                   <h4 className="font-semibold text-foreground">
@@ -436,6 +435,16 @@ export default function ParseNovelSection({
                         <ChevronRight className="w-4 h-4" />
                       </Button>
                     </div>
+                  )}
+                  {sourceNovel.totalPages && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => fetchPage(currentPage)}
+                      disabled={!currentPage || loading}
+                    >
+                      {loading ? 'Fetching...' : 'Chapter Fetch'}
+                    </Button>
                   )}
                 </div>
                 <div className="overflow-x-auto border border-border rounded-lg">


### PR DESCRIPTION
Issue:
Pages novels have no chapter section until they get their first chapter

Solution:
Render it if there's more than one page
Add Chapter Fetch button so that single paged novels always work
Chapter Fetch also allows testing of just parsePage without excess requests