### PR TITLE
Fix: Novelight browse + chapter parse + status parse

### DIFF
--- a/plugins/english/novelight.ts
+++ b/plugins/english/novelight.ts
@@ -106,10 +106,18 @@ class Novelight implements Plugin.PagePlugin {
     for (const child of info) {
       const type = loadedCheerio(child).find('.sub-header').text().trim();
       if (type === 'Status') {
-        status = loadedCheerio(child).find('div.info').text().trim();
+        status = loadedCheerio(child)
+          .find('div.info')
+          .text()
+          .trim()
+          .toLowerCase();
       }
       if (type === 'Translation') {
-        translation = loadedCheerio(child).find('div.info').text().trim();
+        translation = loadedCheerio(child)
+          .find('div.info')
+          .text()
+          .trim()
+          .toLowerCase();
       }
       if (type === 'Author') {
         novel.author = loadedCheerio(child).find('div.info').text().trim();


### PR DESCRIPTION
Fixes #1928

Issues:
Can't parse chapters
Browse bad
Doesn't parse status

Solutions:
Added error catching to parse chapters, somehow works now.
Added latest + filters
Made status parsing toLowerCase