### PR TITLE
Fix: Genesis

### DIFF
--- a/plugins/english/genesis.ts
+++ b/plugins/english/genesis.ts
@@ -12,7 +12,7 @@ class Genesis implements Plugin.PluginBase {
   customCSS = 'src/en/genesis/customCSS.css';
   site = 'https://genesistudio.com';
   api = 'https://api.genesistudio.com';
-  version = '1.1.3';
+  version = '2.0.0';
 
   hideLocked = storage.get('hideLocked');
   pluginSettings = {


### PR DESCRIPTION
Fixed #1836 
Fixes #1740 

Issues:
Genesis site basically entirely changed.

Solution:
Entirely rewrite code

Known problems:
Search doesn't work (But there's only 14 novels)
Non-png novels don't display covers on browse, but that will correct on a full parse