### PR TITLE
feat: Mark down plugins script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ broken-sites-report.json
 .agents/
 .claude/
 .cursor/
+missed-sites-report.json

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format:check": "prettier --check \"./**/*.{js,ts}\"",
     "check:sites": "node scripts/check-plugin-sites.js",
     "check:plugin": "node scripts/live-check-plugin.js",
+    "mark:sites": "node scripts/mark-plugin-sites.js",
     "prepare": "husky"
   },
   "author": "LNReader",

--- a/scripts/mark-plugin-sites.js
+++ b/scripts/mark-plugin-sites.js
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+import path, { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const reportFile = path.join(__dirname, '..', 'broken-sites-report.json');
+const missedFile = path.join(__dirname, '..', 'missed-sites-report.json');
+const pluginDir = path.join(__dirname, '..', 'plugins');
+
+// Language lookup likely incomplete
+const langLookup = {
+  "‎العربية": "arabic",
+  "chinese": "chinese",
+  "English": "english",
+  "Français": "french",
+  "Bahasa Indonesia": "indonesian",
+  "japanese": "japanese",
+  "korean": "korean",
+  "polish": "polish",
+  "Português": "portuguese",
+  "Русский": "russian",
+  "Español": "spanish",
+  "thai": "thai",
+  "Türkçe": "turkish",
+  "Українська": "ukrainian",
+  "Tiếng Việt": "vietnamese",
+}
+
+async function renameFile(oldFile, newFileInject = '.broken') {
+  try {
+    const fileToRename = path.basename(oldFile);
+    const directory = path.dirname(oldFile);
+    const ext = path.extname(fileToRename);
+    const fileBaseName = path.basename(oldFile, ext);
+
+    if (fileBaseName.toString().includes(newFileInject)) {
+      return true
+    }
+
+    // Inject newFileInject into file name
+    const finalNewName = fileBaseName + newFileInject + ext;
+
+    // Construct full path
+    const newPath = path.join(directory, finalNewName);
+
+    // Rename the file
+    await fs.renameSync(oldFile, newPath);
+
+    console.log(`Successfully renamed: ${fileToRename} -> ${finalNewName}`);
+    return true;
+
+  } catch (error) {
+    console.error('Error:', error.message);
+    return false;
+  }
+}
+
+async function searchFilesForString(directory, searchString, options = {}) {
+  const {
+    recursive = false,
+    caseSensitive = false,
+    fileExtensions = ['.ts', '.js'],
+    showLineNumbers = false
+  } = options;
+
+  const results = [];
+
+  async function searchDirectory(dir) {
+    try {
+      const entries = await fs.readdirSync(dir, { withFileTypes: true });
+
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory() && recursive) {
+          await searchDirectory(fullPath);
+        } else if (entry.isFile()) {
+          // Check file extension filter
+          if (fileExtensions && !fileExtensions.includes(path.extname(entry.name))) {
+            continue;
+          }
+
+          try {
+            const content = await fs.readFileSync(fullPath, 'utf8');
+            const searchTerm = caseSensitive ? searchString : searchString.toLowerCase();
+            const searchContent = caseSensitive ? content : content.toLowerCase();
+
+            if (searchContent.includes(searchTerm)) {
+              const fileResult = {
+                file: fullPath,
+                matches: []
+              };
+
+              if (showLineNumbers) {
+                const lines = content.split('\n');
+                lines.forEach((line, index) => {
+                  const checkLine = caseSensitive ? line : line.toLowerCase();
+                  if (checkLine.includes(searchTerm)) {
+                    fileResult.matches.push({
+                      line: index + 1,
+                      content: line.trim()
+                    });
+                  }
+                });
+              }
+
+              results.push(fileResult);
+            }
+          } catch (err) {
+            // Skip files that can't be read as text
+            if (err.code !== 'EISDIR') {
+              console.warn(`Could not read file: ${fullPath}`);
+            }
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`Error reading directory ${dir}:`, err.message);
+    }
+  }
+
+  await searchDirectory(directory);
+  return results;
+}
+
+function displayResults(results, searchString) {
+  if (results.length === 0) {
+    console.log(`\nNo files found containing "${searchString}"\n`);
+    return;
+  }
+
+  console.log(`\nFound "${searchString}" in ${results.length} file(s):\n`);
+
+  results.forEach(result => {
+    console.log(`📄 ${result.file}`);
+
+    if (result.matches.length > 0) {
+      result.matches.forEach(match => {
+        console.log(`   Line ${match.line}: ${match.content}`);
+      });
+    }
+    console.log('');
+  });
+}
+
+
+async function main() {
+  console.log(`Loading ${reportFile}...\n`);
+
+  try {
+    // Read and parse JSON file
+    const jsonData = await fs.readFileSync(reportFile, 'utf8', (err) => err && console.error(err));
+    const data = JSON.parse(jsonData);
+    const broken = data.brokenSites;
+
+    console.log(`Successfully indexed ${broken.length} plugins.\n`);
+
+    const missed = [];
+
+    for (const site of broken) {
+      const lang = langLookup[site.lang];
+      const url = site.url;
+
+      const langDir = path.join(pluginDir, lang);
+
+      const results = await searchFilesForString(langDir, url);
+
+      if (results.length == 0) {
+        console.warn(`No match for ${url}`);
+        missed.push(site);
+        continue;
+      }
+      for (const result of results) {
+        if (!(await renameFile(result.file))) {
+          missed.push(site);
+        }
+      }
+    }
+
+    if (missed.length > 0) {
+      console.log('\n' + '='.repeat(80));
+      console.log('Missed:');
+      console.log('='.repeat(80));
+
+      fs.writeFileSync(
+        missedFile,
+        JSON.stringify(
+          {
+            timestamp: new Date().toISOString(),
+            total: missed.length,
+            brokenSites: missed,
+          },
+          null,
+          2,
+        ),
+      );
+
+      console.log(`\n\nDetailed report saved to: ${missedFile}`);
+    } else {
+      console.log('\n✓ All sites marked!');
+    }
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main().catch(error => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/scripts/mark-plugin-sites.js
+++ b/scripts/mark-plugin-sites.js
@@ -3,6 +3,7 @@
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import path, { dirname } from 'path';
+import languages from './languages.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,24 +11,16 @@ const reportFile = path.join(__dirname, '..', 'broken-sites-report.json');
 const missedFile = path.join(__dirname, '..', 'missed-sites-report.json');
 const pluginDir = path.join(__dirname, '..', 'plugins');
 
-// Language lookup likely incomplete
-const langLookup = {
-  '‎العربية': 'arabic',
-  'chinese': 'chinese',
-  'English': 'english',
-  'Français': 'french',
-  'Bahasa Indonesia': 'indonesian',
-  'japanese': 'japanese',
-  'korean': 'korean',
-  'polish': 'polish',
-  'Português': 'portuguese',
-  'Русский': 'russian',
-  'Español': 'spanish',
-  'thai': 'thai',
-  'Türkçe': 'turkish',
-  'Українська': 'ukrainian',
-  'Tiếng Việt': 'vietnamese',
-};
+// Languages.js is backwards from what I want
+function swap(json) {
+  var ret = {};
+  for (var key in json) {
+    ret[json[key]] = key;
+  }
+  return ret;
+}
+
+const langLookup = swap(languages);
 
 async function renameFile(oldFile, newFileInject = '.broken') {
   try {

--- a/scripts/mark-plugin-sites.js
+++ b/scripts/mark-plugin-sites.js
@@ -54,7 +54,7 @@ async function renameFile(oldFile, newFileInject = '.broken') {
   }
 }
 
-async function updateMultisrc(srcFile, url, optionKey = 'broken') {
+async function updateMultisrc(srcFile, url) {
   try {
     // Read and parse JSON file
     const jsonData = await fs.readFileSync(
@@ -71,6 +71,8 @@ async function updateMultisrc(srcFile, url, optionKey = 'broken') {
       if (siteUrl != url) {
         continue;
       }
+      // Set JSON modifications in here
+      // Checking for existence of options
       if (!source.hasOwnProperty('options')) {
         source.options = {};
       }

--- a/scripts/mark-plugin-sites.js
+++ b/scripts/mark-plugin-sites.js
@@ -63,8 +63,7 @@ async function updateMultisrc(srcFile, url) {
       err => err && console.error(err),
     );
     const data = JSON.parse(jsonData);
-    const date = new Date();
-    const dateWithoutTime = date.toISOString().split('T')[0];
+    const date = Date.now();
 
     for (const source of data) {
       const siteUrl = source.sourceSite;
@@ -77,7 +76,7 @@ async function updateMultisrc(srcFile, url) {
         source.options = {};
       }
       source.options.down = true;
-      source.options.downSince = dateWithoutTime;
+      source.options.downSince = date;
       break;
     }
 

--- a/scripts/mark-plugin-sites.js
+++ b/scripts/mark-plugin-sites.js
@@ -15,7 +15,7 @@ const pluginDir = path.join(__dirname, '..', 'plugins');
 function swap(json) {
   var ret = {};
   for (var key in json) {
-    ret[json[key]] = key;
+    ret[json[key]] = key.toLowerCase();
   }
   return ret;
 }

--- a/scripts/mark-plugin-sites.js
+++ b/scripts/mark-plugin-sites.js
@@ -75,6 +75,12 @@ async function updateMultisrc(srcFile, url) {
       if (!source.hasOwnProperty('options')) {
         source.options = {};
       }
+      if (
+        source.options.hasOwnProperty('down') &&
+        source.options.down === true
+      ) {
+        return true;
+      }
       source.options.down = true;
       source.options.downSince = date;
       break;


### PR DESCRIPTION
Script that renames sites from `check-plugin-sites.js` to `.broken` versions.
Also adds options.down and options.downSince to multisrc files.

Obviously, you should manually verify the list of sites before running this script, as the previous script generates plenty of false positives.

Makes #1973 easier