### PR TITLE
feat: Make multisrc utilize down status to generate .broken

### DIFF
--- a/plugins/multisrc/fictioneer/generator.js
+++ b/plugins/multisrc/fictioneer/generator.js
@@ -10,6 +10,7 @@ export const generateAll = function () {
   return list.map(source => {
     console.log(
       `[fictioneer] Generating: ${source.id}${' '.repeat(20 - source.id.length)}`,
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
     );
     return generator(source);
   });
@@ -37,5 +38,6 @@ export default plugin;
     lang: source.options?.lang || 'English',
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/plugins/multisrc/fictioneer/template.ts
+++ b/plugins/multisrc/fictioneer/template.ts
@@ -6,6 +6,8 @@ import { Filters } from '@libs/filterInputs';
 
 type FictioneerOptions = {
   browsePage: string;
+  down?: boolean;
+  downSince?: string;
   lang?: string;
   versionIncrements?: number;
 };

--- a/plugins/multisrc/generate-multisrc-plugins.js
+++ b/plugins/multisrc/generate-multisrc-plugins.js
@@ -5,6 +5,7 @@ import fs from 'fs';
 //   lang: string;
 //   filename: string;
 //   pluginScript: string;
+//   down?: boolean;
 // };
 
 // export type ScrpitGeneratorFunction = () => GeneratedScript[];
@@ -19,7 +20,7 @@ const generate = async name => {
     if (!isScriptGenerator(generateAll)) return false;
     const sources = generateAll();
     for (let source of sources) {
-      const { lang, filename, pluginScript } = source;
+      const { lang, filename, pluginScript, down } = source;
       if (!lang || !filename || !pluginScript) {
         console.warn(name, ': lang, filename, pluginScript are required!');
         continue;
@@ -28,7 +29,8 @@ const generate = async name => {
       const filePath = path.join(
         pluginsDir,
         lang.toLowerCase(),
-        filename.replace(/[\s-.]+/g, '') + `[${name}].ts`,
+        filename.replace(/[\s-\.]+/g, '') +
+          `[${name}]${down ? '.down' : ''}.ts`,
       );
       fs.writeFileSync(filePath, pluginScript, { encoding: 'utf-8' });
     }

--- a/plugins/multisrc/generate-multisrc-plugins.js
+++ b/plugins/multisrc/generate-multisrc-plugins.js
@@ -30,7 +30,7 @@ const generate = async name => {
         pluginsDir,
         lang.toLowerCase(),
         filename.replace(/[\s-\.]+/g, '') +
-          `[${name}]${down ? '.down' : ''}.ts`,
+          `[${name}]${down ? '.broken' : ''}.ts`,
       );
       fs.writeFileSync(filePath, pluginScript, { encoding: 'utf-8' });
     }

--- a/plugins/multisrc/hotnovelpub/generator.js
+++ b/plugins/multisrc/hotnovelpub/generator.js
@@ -36,7 +36,13 @@ export const generateAll = function () {
       return { ...p, filters };
     })
     .map(metadata => {
-      console.log(`[hotnovelpub]: Generating`, metadata.id);
+      console.log(
+        `[hotnovelpub]: Generating`,
+        metadata.id,
+        metadata.options?.downSince
+          ? `since: ${metadata.options?.downSince}`
+          : '',
+      );
       return generator(metadata);
     });
 };
@@ -56,5 +62,6 @@ export default plugin;
     lang: lang[metadata?.options?.lang || 'en'] || 'english',
     filename: metadata.sourceName,
     pluginScript,
+    down: metadata.options?.down || false,
   };
 };

--- a/plugins/multisrc/hotnovelpub/template.ts
+++ b/plugins/multisrc/hotnovelpub/template.ts
@@ -13,6 +13,8 @@ export type HotNovelPubMetadata = {
 
 type HotNovelPubOptions = {
   lang?: string;
+  down?: boolean;
+  downSince?: string;
 };
 
 export class HotNovelPubPlugin implements Plugin.PluginBase {

--- a/plugins/multisrc/ifreedom/generator.js
+++ b/plugins/multisrc/ifreedom/generator.js
@@ -9,7 +9,13 @@ const folder = dirname(fileURLToPath(import.meta.url));
 export const generateAll = function () {
   return list.map(metadata => {
     metadata.filters = Object.assign(defaultSettings.filters, metadata.filters);
-    console.log(`[ifreedom]: Generating`, metadata.id);
+    console.log(
+      `[ifreedom]: Generating`,
+      metadata.id,
+      metadata.options?.downSince
+        ? `since: ${metadata.options?.downSince}`
+        : '',
+    );
     return generator(metadata);
   });
 };
@@ -29,5 +35,6 @@ export default plugin;
     lang: 'russian',
     filename: metadata.sourceName,
     pluginScript,
+    down: metadata.options?.down || false,
   };
 };

--- a/plugins/multisrc/ifreedom/template.ts
+++ b/plugins/multisrc/ifreedom/template.ts
@@ -10,6 +10,13 @@ export type IfreedomMetadata = {
   sourceSite: string;
   sourceName: string;
   filters?: Filters;
+  options?: IfreedomOptions;
+};
+
+type IfreedomOptions = {
+  lang?: string;
+  down?: boolean;
+  downSince?: string;
 };
 
 export class IfreedomPlugin implements Plugin.PluginBase {

--- a/plugins/multisrc/lightnovelwp/generator.js
+++ b/plugins/multisrc/lightnovelwp/generator.js
@@ -15,7 +15,14 @@ export const generateAll = function () {
       source.filters = JSON.parse(filters).filters;
     }
     console.log(
-      `[lightnovelwp] Generating: ${source.id}${' '.repeat(20 - source.id.length)} ${source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      '[lightnovelwp] Generating:',
+      source.id.padEnd(20),
+      source.options?.down
+        ? '🔽site is down🔽'
+        : source.filters
+          ? '🔎with filters🔍'
+          : '🚫 no filters 🚫',
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
     );
     return generator(source);
   });
@@ -39,5 +46,6 @@ export default plugin;
     lang: source.options?.lang || 'English',
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/plugins/multisrc/lightnovelwp/template.ts
+++ b/plugins/multisrc/lightnovelwp/template.ts
@@ -9,6 +9,8 @@ import { storage } from '@libs/storage';
 
 type LightNovelWPOptions = {
   reverseChapters?: boolean;
+  down?: boolean;
+  downSince?: string;
   lang?: string;
   versionIncrements?: number;
   seriesPath?: string;

--- a/plugins/multisrc/madara/generator.js
+++ b/plugins/multisrc/madara/generator.js
@@ -15,7 +15,14 @@ export const generateAll = function () {
       source.filters = JSON.parse(filters).filters;
     }
     console.log(
-      `[madara] Generating: ${source.id}${' '.repeat(20 - source.id.length)} ${source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      '[madara] Generating:',
+      source.id.padEnd(20),
+      source.options?.down
+        ? '🔽site is down🔽'
+        : source.filters
+          ? '🔎with filters🔍'
+          : '🚫 no filters 🚫',
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
     );
     return generator(source);
   });
@@ -35,5 +42,6 @@ export default plugin;
     lang: source.options?.lang || 'English',
     filename: source.sourceName.replace(/[^\w]/g, ''),
     pluginScript,
+    down: source.options?.down,
   };
 };

--- a/plugins/multisrc/madara/sources.json
+++ b/plugins/multisrc/madara/sources.json
@@ -25,15 +25,6 @@
     }
   },
   {
-    "id": "freenovel.me",
-    "sourceSite": "https://freenovel.me/",
-    "sourceName": "FreeNovelMe",
-    "options": {
-      "down": true,
-      "downSince": "2024-03-04"
-    }
-  },
-  {
     "id": "1stkissnovel",
     "sourceSite": "https://1stkissnovel.org/",
     "sourceName": "FirstKissNovel",
@@ -98,15 +89,6 @@
     }
   },
   {
-    "id": "readwebnovels",
-    "sourceSite": "https://readwebnovels.net/",
-    "sourceName": "ReadWebNovels",
-    "options": {
-      "down": true,
-      "downSince": "2024-03-04"
-    }
-  },
-  {
     "id": "wbnovel",
     "sourceSite": "https://wbnovel.com/",
     "sourceName": "WBNovel",
@@ -137,16 +119,6 @@
     "options": {
       "useNewChapterEndpoint": true,
       "lang": "Indonesian"
-    }
-  },
-  {
-    "id": "onlymtl",
-    "sourceSite": "https://www.onlymtl.com/",
-    "sourceName": "OnlyMTL",
-    "options": {
-      "useNewChapterEndpoint": true,
-      "down": true,
-      "downSince": "2024-03-04"
     }
   },
   {
@@ -195,16 +167,6 @@
     }
   },
   {
-    "id": "mtlnovel.club",
-    "sourceSite": "https://mtlnovel.club/",
-    "sourceName": "MTLNovel.Club",
-    "options": {
-      "useNewChapterEndpoint": true,
-      "down": true,
-      "downSince": "2024-03-04"
-    }
-  },
-  {
     "id": "guavaread",
     "sourceSite": "https://guavaread.com/",
     "sourceName": "Guavaread",
@@ -212,26 +174,6 @@
       "useNewChapterEndpoint": true,
       "down": true,
       "downSince": 1768289212912
-    }
-  },
-  {
-    "id": "sweetEscapeTL",
-    "sourceSite": "https://sweetescapetranslations.com/",
-    "sourceName": "Sweet Escape Translations",
-    "options": {
-      "useNewChapterEndpoint": false,
-      "down": true,
-      "downSince": "2024-03-04"
-    }
-  },
-  {
-    "id": "novelstic",
-    "sourceSite": "https://novelstic.com/",
-    "sourceName": "Novelstic",
-    "options": {
-      "useNewChapterEndpoint": true,
-      "down": true,
-      "downSince": "2024-03-04"
     }
   },
   {
@@ -255,34 +197,6 @@
     "sourceName": "Zetro Translation",
     "options": {
       "hasLocked": true
-    }
-  },
-  {
-    "id": "nocturneTLS",
-    "sourceSite": "https://nocturnetls.net/",
-    "sourceName": "Nocturne Translations",
-    "options": {
-      "down": true,
-      "downSince": "2024-03-04"
-    }
-  },
-  {
-    "id": "novelroom",
-    "sourceSite": "https://novelroom.net/",
-    "sourceName": "Novelroom.net",
-    "options": {
-      "down": true,
-      "downSince": "2024-03-04"
-    }
-  },
-  {
-    "id": "novelr18",
-    "sourceSite": "https://novelr18.com/",
-    "sourceName": "NovelR18",
-    "options": {
-      "useNewChapterEndpoint": true,
-      "down": true,
-      "downSince": "2024-03-04"
     }
   },
   {

--- a/plugins/multisrc/madara/sources.json
+++ b/plugins/multisrc/madara/sources.json
@@ -25,6 +25,15 @@
     }
   },
   {
+    "id": "freenovel.me",
+    "sourceSite": "https://freenovel.me/",
+    "sourceName": "FreeNovelMe",
+    "options": {
+      "down": true,
+      "downSince": "2024-03-04"
+    }
+  },
+  {
     "id": "1stkissnovel",
     "sourceSite": "https://1stkissnovel.org/",
     "sourceName": "FirstKissNovel",
@@ -89,6 +98,15 @@
     }
   },
   {
+    "id": "readwebnovels",
+    "sourceSite": "https://readwebnovels.net/",
+    "sourceName": "ReadWebNovels",
+    "options": {
+      "down": true,
+      "downSince": "2024-03-04"
+    }
+  },
+  {
     "id": "wbnovel",
     "sourceSite": "https://wbnovel.com/",
     "sourceName": "WBNovel",
@@ -119,6 +137,16 @@
     "options": {
       "useNewChapterEndpoint": true,
       "lang": "Indonesian"
+    }
+  },
+  {
+    "id": "onlymtl",
+    "sourceSite": "https://www.onlymtl.com/",
+    "sourceName": "OnlyMTL",
+    "options": {
+      "useNewChapterEndpoint": true,
+      "down": true,
+      "downSince": "2024-03-04"
     }
   },
   {
@@ -167,6 +195,16 @@
     }
   },
   {
+    "id": "mtlnovel.club",
+    "sourceSite": "https://mtlnovel.club/",
+    "sourceName": "MTLNovel.Club",
+    "options": {
+      "useNewChapterEndpoint": true,
+      "down": true,
+      "downSince": "2024-03-04"
+    }
+  },
+  {
     "id": "guavaread",
     "sourceSite": "https://guavaread.com/",
     "sourceName": "Guavaread",
@@ -174,6 +212,26 @@
       "useNewChapterEndpoint": true,
       "down": true,
       "downSince": 1768289212912
+    }
+  },
+  {
+    "id": "sweetEscapeTL",
+    "sourceSite": "https://sweetescapetranslations.com/",
+    "sourceName": "Sweet Escape Translations",
+    "options": {
+      "useNewChapterEndpoint": false,
+      "down": true,
+      "downSince": "2024-03-04"
+    }
+  },
+  {
+    "id": "novelstic",
+    "sourceSite": "https://novelstic.com/",
+    "sourceName": "Novelstic",
+    "options": {
+      "useNewChapterEndpoint": true,
+      "down": true,
+      "downSince": "2024-03-04"
     }
   },
   {
@@ -197,6 +255,34 @@
     "sourceName": "Zetro Translation",
     "options": {
       "hasLocked": true
+    }
+  },
+  {
+    "id": "nocturneTLS",
+    "sourceSite": "https://nocturnetls.net/",
+    "sourceName": "Nocturne Translations",
+    "options": {
+      "down": true,
+      "downSince": "2024-03-04"
+    }
+  },
+  {
+    "id": "novelroom",
+    "sourceSite": "https://novelroom.net/",
+    "sourceName": "Novelroom.net",
+    "options": {
+      "down": true,
+      "downSince": "2024-03-04"
+    }
+  },
+  {
+    "id": "novelr18",
+    "sourceSite": "https://novelr18.com/",
+    "sourceName": "NovelR18",
+    "options": {
+      "useNewChapterEndpoint": true,
+      "down": true,
+      "downSince": "2024-03-04"
     }
   },
   {

--- a/plugins/multisrc/madara/template.ts
+++ b/plugins/multisrc/madara/template.ts
@@ -13,6 +13,8 @@ const includesAny = (str: string, keywords: string[]) =>
 
 type MadaraOptions = {
   useNewChapterEndpoint?: boolean;
+  down?: boolean;
+  downSince?: string;
   lang?: string;
   orderBy?: string;
   versionIncrements?: number;

--- a/plugins/multisrc/mtlnovel/generator.js
+++ b/plugins/multisrc/mtlnovel/generator.js
@@ -18,7 +18,12 @@ export const generateAll = function () {
     }
     console.log(
       `[mtlnovel] Generating: ${source.id}`.padEnd(35),
-      source.filters ? '🔎with filters🔍' : '🚫 no filters 🚫',
+      source.options?.down
+        ? '🔽site is down🔽'
+        : source.filters
+          ? '🔎with filters🔍'
+          : '🚫 no filters 🚫',
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
     );
     return generator(source);
   });
@@ -40,5 +45,6 @@ export default plugin;
     lang: source.options?.lang || 'English',
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/plugins/multisrc/mtlnovel/template.ts
+++ b/plugins/multisrc/mtlnovel/template.ts
@@ -7,6 +7,8 @@ import { Filters } from '@libs/filterInputs';
 
 type MTLNovelOptions = {
   lang?: string;
+  down?: boolean;
+  downSince?: string;
 };
 
 export type MTLNovelMetadata = {

--- a/plugins/multisrc/novelcool/generator.js
+++ b/plugins/multisrc/novelcool/generator.js
@@ -36,5 +36,6 @@ export default plugin;
     lang: source.options.lang,
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/plugins/multisrc/novelcool/template.ts
+++ b/plugins/multisrc/novelcool/template.ts
@@ -8,6 +8,8 @@ type NovelCoolOptions = {
   lang: string;
   langCode: string;
   app: Record<string, string>;
+  down?: boolean;
+  downSince?: string;
 };
 
 export type NovelCoolMetadata = {

--- a/plugins/multisrc/ranobes/generator.js
+++ b/plugins/multisrc/ranobes/generator.js
@@ -7,7 +7,13 @@ const folder = dirname(fileURLToPath(import.meta.url));
 
 export const generateAll = function () {
   return list.map(metadata => {
-    console.log(`[ranobes]: Generating`, metadata.id);
+    console.log(
+      `[ranobes]: Generating`,
+      metadata.id,
+      metadata.options?.downSince
+        ? `since: ${metadata.options?.downSince}`
+        : '',
+    );
     return generator(metadata);
   });
 };
@@ -27,5 +33,6 @@ export default plugin;
     lang: metadata.options.lang,
     filename: metadata.sourceName,
     pluginScript,
+    down: metadata.options?.down || false,
   };
 };

--- a/plugins/multisrc/ranobes/template.ts
+++ b/plugins/multisrc/ranobes/template.ts
@@ -6,6 +6,8 @@ import { NovelStatus } from '@libs/novelStatus';
 type RanobesOptions = {
   lang?: string;
   path: string;
+  down?: boolean;
+  downSince?: string;
 };
 
 export type RanobesMetadata = {

--- a/plugins/multisrc/readnovelfull/generator.js
+++ b/plugins/multisrc/readnovelfull/generator.js
@@ -15,7 +15,9 @@ export const generateAll = function () {
       source.filters = JSON.parse(filters).filters;
     }
     console.log(
-      `[readnovelfull] Generating: ${source.id}${' '.repeat(20 - source.id.length)} ${source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      `[readnovelfull] Generating: ${source.id}${' '.repeat(20 - source.id.length)}`,
+      `${source.options?.down ? '🔽site is down🔽' : source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
     );
     return generator(source);
   });
@@ -35,5 +37,6 @@ export default plugin;
     lang: source.options?.lang || 'English',
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/plugins/multisrc/readnovelfull/template.ts
+++ b/plugins/multisrc/readnovelfull/template.ts
@@ -25,6 +25,8 @@ type ReadNovelFullOptions = {
   noPages?: string[];
   pageAsPath?: boolean;
   customJs?: string;
+  down?: boolean;
+  downSince?: string;
 };
 
 export type ReadNovelFullMetadata = {

--- a/plugins/multisrc/readwn/generator.js
+++ b/plugins/multisrc/readwn/generator.js
@@ -15,7 +15,9 @@ export const generateAll = function () {
       source.filters = JSON.parse(filters).filters;
     }
     console.log(
-      `[readwn] Generating: ${source.id}${' '.repeat(20 - source.id.length)} ${source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      `[readwn] Generating: ${source.id}${' '.repeat(20 - source.id.length)}`,
+      `${source.options?.down ? '🔽site is down🔽' : source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
     );
     return generator(source);
   });
@@ -36,5 +38,6 @@ export default plugin;
     lang: 'english',
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/plugins/multisrc/readwn/template.ts
+++ b/plugins/multisrc/readwn/template.ts
@@ -7,6 +7,8 @@ import dayjs from 'dayjs';
 
 type ReadwnOptions = {
   versionIncrements?: number;
+  down?: boolean;
+  downSince?: string;
 };
 
 export type ReadwnMetadata = {

--- a/plugins/multisrc/rulate/generator.js
+++ b/plugins/multisrc/rulate/generator.js
@@ -25,7 +25,11 @@ export const generateAll = function () {
       );
     }
 
-    console.log(`[rulate]: Generating`, source.id);
+    console.log(
+      `[rulate]: Generating`,
+      source.id,
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
+    );
     return generator(source);
   });
 };
@@ -45,5 +49,6 @@ export default plugin;
     lang: 'russian',
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/plugins/multisrc/rulate/template.ts
+++ b/plugins/multisrc/rulate/template.ts
@@ -11,11 +11,18 @@ export type RulateMetadata = {
   filters?: Filters;
   versionIncrements: number;
   key: string;
+  options?: RulateOptions;
 };
 
 const headers = {
   'User-Agent': 'RuLateApp Android',
   'accept-encoding': 'gzip',
+};
+
+type RulateOptions = {
+  lang?: string;
+  down?: boolean;
+  downSince?: string;
 };
 
 export class RulatePlugin implements Plugin.PluginBase {

--- a/plugins/multisrc/webnovelworld/generator.js
+++ b/plugins/multisrc/webnovelworld/generator.js
@@ -15,7 +15,8 @@ export const generateAll = function () {
       source.filters = JSON.parse(filters).filters;
     }
     console.log(
-      `[webnovelworld] Generating: ${source.id}${' '.repeat(20 - source.id.length)} ${source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      `[webnovelworld] Generating: ${source.id}${' '.repeat(20 - source.id.length)} ${source.options?.down ? '🔽site is down🔽' : source.filters ? '🔎with filters🔍' : '🚫no filters🚫'}`,
+      source.options?.downSince ? `since: ${source.options?.downSince}` : '',
     );
     return generator(source);
   });
@@ -36,5 +37,6 @@ export default plugin;
     lang: source.options?.lang || 'English',
     filename: source.sourceName,
     pluginScript,
+    down: source.options?.down || false,
   };
 };

--- a/scripts/build-plugin-manifest.js
+++ b/scripts/build-plugin-manifest.js
@@ -139,6 +139,7 @@ for (let language in languages) {
       iconUrl: `${STATIC_LINK}/${icon || 'siteNotAvailable.png'}`,
       customJS: customJS ? `${STATIC_LINK}/${customJS}` : undefined,
       customCSS: customCSS ? `${STATIC_LINK}/${customCSS}` : undefined,
+      down: plugin.endsWith('.broken.js'),
     };
 
     if (pluginSet.has(id)) {


### PR DESCRIPTION
Adds official support for options.down, which generates `.broken.ts` versions of plugins, allowing us to mark sites as down without deleting their entries, and keep the plugin list cleaner.

Restoration simply requires removing the down line, or setting it to false (and resetting down since, presumably).

Effects:
Will disable 28 multisrc plugins