### PR TITLE
fix: Novelfire scrape (bold and ToC)

### DIFF
--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -13,6 +13,8 @@ class NovelFire implements Plugin.PluginBase {
   icon = 'src/en/novelfire/icon.png';
   site = 'https://novelfire.net/';
 
+  novelList = [];
+
   singlePage = storage.get('singlePage');
   pluginSettings = {
     singlePage: {
@@ -45,6 +47,9 @@ class NovelFire implements Plugin.PluginBase {
       filters,
     }: Plugin.PopularNovelsOptions<typeof this.filters>,
   ): Promise<Plugin.NovelItem[]> {
+    if (pageNo == 1) {
+      this.novelList = [];
+    }
     let url = this.site + 'search-adv';
     if (showLatestNovels) {
       url += `?ctgcon=and&totalchapter=0&ratcon=min&rating=0&status=-1&sort=date&tagcon=and&page=${pageNo}`;
@@ -86,6 +91,12 @@ class NovelFire implements Plugin.PluginBase {
           .attr('href');
 
         if (!novelPath) return;
+
+        if (this.novelList.includes(novelPath)) {
+          return;
+        } else {
+          this.novelList.push(novelPath);
+        }
 
         return {
           name: novelName,


### PR DESCRIPTION
Fixes #1999 
Fixes #2008 

## Bold scraping issue (Original)
Added strong to whitelist, which is definitely good.

Also I recalled a possible pattern of problem tags starting with "nf", so added that as a condition.
Can't confirm if the tag removal still works, haven't been able to find a tag in 50 I checked. Will run on my phone for a while and see if I encounter one.
Either way, better than current version if you encounter a strong tag.

Haven't seen any issues in 4 days of running this so far.

# Fix (Reversion from ajax ToC)
NovelFire reverted to their old chapter setup, so I pulled old code from @error7404 's [commits](https://github.com/lnreader/lnreader-plugins/commit/d8301602465430cb9655d65c221d8babf7504b7d)
Attributed commits so there is credit in the squash.
Added error handling, so if they return to ajax, there will not be issues.
Correctly implemented monopaging option, with default of paged when using fallback.
Yes, fallback is the default, because I suspect there's a decent chance they return to ajax in the future. This handles both scenarios, with an extra 404 (which should use barely any data) when pulling a table of contents (rare operation, at least for me).

Of note: The monopage option does require restarting the app to take effect. Seems to be an app-based bug to me.