### PR TITLE
fix: Madara Double slashes

### DIFF
--- a/plugins/multisrc/madara/template.ts
+++ b/plugins/multisrc/madara/template.ts
@@ -149,7 +149,7 @@ class MadaraPlugin implements Plugin.PluginBase {
         const novel: Plugin.NovelItem = {
           name: novelName,
           cover: novelCover,
-          path: novelUrl.replace(/https?:\/\/.*?\//, '/'),
+          path: novelUrl.replace(/https?:\/\/.*?\//, ''),
         };
         novels.push(novel);
       },
@@ -347,7 +347,7 @@ class MadaraPlugin implements Plugin.PluginBase {
       if (chapterUrl && chapterUrl != '#' && !(locked && this.hideLocked)) {
         chapters.push({
           name: chapterName,
-          path: chapterUrl.replace(/https?:\/\/.*?\//, '/'),
+          path: chapterUrl.replace(/https?:\/\/.*?\//, ''),
           releaseTime: releaseDate || null,
           chapterNumber: totalChapters - chapterIndex,
         });


### PR DESCRIPTION
As all URLs in sources.json end in /, starting any novel URL with / will result in double slashes between the two.
For most sources, this causes no issue. However, it appears to cause issues for others.

Setting this to `''` will reduce the amount of double slashes with no risk of issue.