### PR TITLE
fix: change novel.totalPages calculation to divide by 50 instead of 100

### DIFF
--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -9,7 +9,7 @@ import { storage } from '@libs/storage';
 class NovelFire implements Plugin.PluginBase {
   id = 'novelfire';
   name = 'Novel Fire';
-  version = '1.1.8';
+  version = '1.1.9';
   icon = 'src/en/novelfire/icon.png';
   site = 'https://novelfire.net/';
 

--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -285,7 +285,7 @@ class NovelFire implements Plugin.PluginBase {
         .parent()
         .text()
         .trim();
-      novel.totalPages = Math.ceil(parseInt(totalChapters) / 100);
+      novel.totalPages = Math.ceil(parseInt(totalChapters) / 50);
       if (this.singlePage) {
         novel.chapters = await this.getAllChaptersForce(
           novelPath,


### PR DESCRIPTION
Fixes: #2097

#### Checklist

- [X] Update version code if an existing plugin was modified
- [ ] Test changes in Plugin Playground or the app
- [X] Reference related issues in the PR body (e.g. Closes #xyz)
