### PR TITLE
fix: Novel fire chapter fetch issue

### DIFF
--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -115,7 +115,7 @@ class NovelFire implements Plugin.PluginBase {
   ): Promise<Plugin.ChapterItem[]> {
     const allChapters: Plugin.ChapterItem[] = [];
 
-    const url = `${this.site}listChapterDataAjax`;
+    const url = `${this.site}ajax/listChapterDataAjax`;
     const params = new URLSearchParams({
       draw: '1',
       'columns[0][data]': 'n_sort',

--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -9,7 +9,7 @@ import { storage } from '@libs/storage';
 class NovelFire implements Plugin.PluginBase {
   id = 'novelfire';
   name = 'Novel Fire';
-  version = '1.1.8';
+  version = '1.1.9';
   icon = 'src/en/novelfire/icon.png';
   site = 'https://novelfire.net/';
 

--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -111,11 +111,41 @@ class NovelFire implements Plugin.PluginBase {
   async getAllChapters(
     novelPath: string,
     post_id: string,
+    totalChapters: string,
   ): Promise<Plugin.ChapterItem[]> {
     const allChapters: Plugin.ChapterItem[] = [];
 
-    const url = `${this.site}listChapterDataAjax?post_id=${post_id}`;
-    const result = await fetchApi(url);
+    const url = `${this.site}listChapterDataAjax`;
+    const params = new URLSearchParams({
+      draw: '1',
+      'columns[0][data]': 'n_sort',
+      'columns[0][name]': 'cmm_posts_detail.n_sort',
+      'columns[0][searchable]': 'true',
+      'columns[0][orderable]': 'true',
+      'columns[0][search][value]': '',
+      'columns[0][search][regex]': 'false',
+
+      'columns[1][data]': 'bookmark_created_at',
+      'columns[1][name]': 'bookmark_chapters.created_at',
+      'columns[1][searchable]': 'false',
+      'columns[1][orderable]': 'true',
+      'columns[1][search][value]': '',
+      'columns[1][search][regex]': 'false',
+
+      'order[0][column]': '0',
+      'order[0][dir]': 'asc',
+      'order[0][name]': 'cmm_posts_detail.n_sort',
+
+      start: '0',
+      length: totalChapters,
+      'search[value]': '',
+      'search[regex]': 'false',
+      post_id: post_id,
+      only_bookmark: 'false',
+      _: Date.now().toString(),
+    });
+
+    const result = await fetchApi(`${url}?${params.toString()}`);
     const body = await result.text();
 
     if (body.includes('You are being rate limited')) {
@@ -219,8 +249,6 @@ class NovelFire implements Plugin.PluginBase {
     const $ = await this.getCheerio(this.site + novelPath, false);
     const baseUrl = this.site;
 
-    let post_id = '0';
-
     const novel: Partial<Plugin.SourceNovel & { totalPages: number }> = {
       path: novelPath,
       totalPages: 1,
@@ -276,10 +304,18 @@ class NovelFire implements Plugin.PluginBase {
 
     novel.rating = parseFloat($('.nub').text().trim());
 
-    post_id = $('#novel-report').attr('report-post_id') || '0';
+    const post_id = $('#novel-report').attr('report-post_id') || '0';
+    const totalChapters = $('.header-stats i.icon-book-open')
+      .parent()
+      .text()
+      .trim();
 
     try {
-      novel.chapters = await this.getAllChapters(novelPath, post_id);
+      novel.chapters = await this.getAllChapters(
+        novelPath,
+        post_id,
+        totalChapters,
+      );
     } catch (error) {
       const totalChapters = $('.header-stats .icon-book-open')
         .parent()

--- a/plugins/english/novelfire.ts
+++ b/plugins/english/novelfire.ts
@@ -285,7 +285,7 @@ class NovelFire implements Plugin.PluginBase {
         .parent()
         .text()
         .trim();
-      novel.totalPages = Math.ceil(parseInt(totalChapters) / 100);
+      novel.totalPages = Math.ceil(parseInt(totalChapters) / 50);
       if (this.singlePage) {
         novel.chapters = await this.getAllChaptersForce(
           novelPath,


### PR DESCRIPTION
Looks like in the paged mode changing the total pages to divide by the number of chapters per page to 50 instead of 100 fixed the missing chapters. Tested in Plugin Playground and the app and it seems to be working. 

I think the issue started because Novel Fire used to have 100 chapters per page and they changed it to 50.

Closes issue #2097

#### Checklist

- [X] Update version code if an existing plugin was modified
- [X] Test changes in Plugin Playground or the app
- [X] Reference related issues in the PR body (e.g. Closes #xyz)
