### PR TITLE
fix(novelbuddy): wrap summary in <div> so cheerio always HTML-parses it

### DIFF
--- a/plugins/english/novelbuddy.ts
+++ b/plugins/english/novelbuddy.ts
@@ -9,7 +9,7 @@ class NovelBuddy implements Plugin.PluginBase {
   name = 'NovelBuddy';
   site = 'https://novelbuddy.com/';
   api = 'https://api.novelbuddy.com/';
-  version = '2.1.0';
+  version = '2.1.1';
   icon = 'src/en/novelbuddy/icon.png';
 
   parseNovels(body: Response): Plugin.NovelItem[] {
@@ -97,7 +97,12 @@ class NovelBuddy implements Plugin.PluginBase {
     };
     novel.status = map[rawStatus.toLowerCase()] ?? NovelStatus.Unknown;
 
-    const summary = $(initialManga.summary || '');
+    // Wrap in <div> before passing to $(): when the API returns plain text (no leading
+    // `<` tag) cheerio's $() treats the input as a CSS selector, and any `.` in the text
+    // (e.g. punctuation in "I was inside a novel.") trips the selector parser with
+    // "Expected name, found ." and the entire parseNovel call fails. Wrapping forces the
+    // HTML-parsing branch regardless of whether the summary is plain text or HTML.
+    const summary = $('<div>' + (initialManga.summary || '') + '</div>');
     summary.find('br').replaceWith('\n');
     summary.find('p').before('\n').after('\n\n');
 


### PR DESCRIPTION
## Bug

`parseNovel` calls `$(initialManga.summary || '')`. Cheerio's `$()` only takes the HTML branch when the input starts with `<` — otherwise it parses the input as a **CSS selector**. The novelbuddy API returns `initialManga.summary` as plain text for many novels (e.g. *Trash of the Count's Family*, where the summary is `"When I opened my eyes, I was inside a novel."`), so the selector parser hits the first `.` from punctuation and throws:

```
Error: Expected name, found .
```

The whole `parseNovel` call fails and the novel page can't be opened.

## Repro

1. Open NovelBuddy
2. Open *Trash of the Count's Family*
3. Details fail with `Expected name, found .`

## Fix

Wrap the summary in a `<div>` before passing to `$()`. Plain text becomes `<div>plain text</div>` (parses as HTML, `.text()` returns the original string), HTML stays HTML, and the existing `.find('br')` / `.find('p')` transforms still work either way.

Bumps version `2.1.0` → `2.1.1`.