### PR TITLE
fix(faqwikius): The website moved all content to /novel.

### DIFF
--- a/plugins/english/faqwikius.ts
+++ b/plugins/english/faqwikius.ts
@@ -7,7 +7,7 @@ class FaqWikiUs implements Plugin.PluginBase {
   id = 'FWK.US';
   name = 'Faq Wiki';
   site = 'https://faqwiki.us/novel';
-  version = '2.0.1';
+  version = '3.0.1';
   icon = 'src/en/faqwikius/icon.png';
 
   parseNovels(loadedCheerio: CheerioAPI, searchTerm?: string) {

--- a/plugins/english/faqwikius.ts
+++ b/plugins/english/faqwikius.ts
@@ -6,7 +6,7 @@ import { NovelStatus } from '@libs/novelStatus';
 class FaqWikiUs implements Plugin.PluginBase {
   id = 'FWK.US';
   name = 'Faq Wiki';
-  site = 'https://faqwiki.us/';
+  site = 'https://faqwiki.us/novel';
   version = '2.0.1';
   icon = 'src/en/faqwikius/icon.png';
 

--- a/plugins/english/faqwikius.ts
+++ b/plugins/english/faqwikius.ts
@@ -12,7 +12,6 @@ class FaqWikiUs implements Plugin.PluginBase {
 
   parseNovels(loadedCheerio: CheerioAPI, searchTerm?: string) {
     let novels: Plugin.NovelItem[] = [];
-    loadedCheerio('script').remove();
 
     loadedCheerio('.plt-page-item').each((index, element) => {
       const name = loadedCheerio(element)
@@ -58,6 +57,7 @@ class FaqWikiUs implements Plugin.PluginBase {
   async parseNovel(path: string): Promise<Plugin.SourceNovel> {
     const body = await fetchApi(this.site + path).then(res => res.text());
     const loadedCheerio = parseHTML(body);
+    loadedCheerio('script').remove();
 
     const novel: Plugin.SourceNovel = {
       path,

--- a/plugins/english/faqwikius.ts
+++ b/plugins/english/faqwikius.ts
@@ -12,6 +12,7 @@ class FaqWikiUs implements Plugin.PluginBase {
 
   parseNovels(loadedCheerio: CheerioAPI, searchTerm?: string) {
     let novels: Plugin.NovelItem[] = [];
+    loadedCheerio('script').remove();
 
     loadedCheerio('.plt-page-item').each((index, element) => {
       const name = loadedCheerio(element)

--- a/plugins/english/faqwikius.ts
+++ b/plugins/english/faqwikius.ts
@@ -10,7 +10,9 @@ class FaqWikiUs implements Plugin.PluginBase {
   version = '3.0.1';
   icon = 'src/en/faqwikius/icon.png';
 
-  parseNovels(loadedCheerio: CheerioAPI, searchTerm?: string) {
+  // Parses a list of NovelItem objects from already-loaded Cheerio HTML.
+  // "List" clarifies it returns NovelItem[] (used by popularNovels and searchNovels).
+  parseNovelList(loadedCheerio: CheerioAPI, searchTerm?: string) {
     let novels: Plugin.NovelItem[] = [];
 
     loadedCheerio('.plt-page-item').each((index, element) => {
@@ -51,10 +53,12 @@ class FaqWikiUs implements Plugin.PluginBase {
     const body = await fetchApi(this.site).then(res => res.text());
     const loadedCheerio = parseHTML(body);
 
-    return this.parseNovels(loadedCheerio);
+    return this.parseNovelList(loadedCheerio);
   }
 
-  async parseNovel(path: string): Promise<Plugin.SourceNovel> {
+  // Fetches and parses a single novel's full details page (metadata, chapters, status).
+  // "Details" distinguishes it from the list parser above.
+  async parseNovelDetails(path: string): Promise<Plugin.SourceNovel> {
     const body = await fetchApi(this.site + path).then(res => res.text());
     const loadedCheerio = parseHTML(body);
     loadedCheerio('script').remove();
@@ -182,7 +186,7 @@ class FaqWikiUs implements Plugin.PluginBase {
     const body = await fetchApi(this.site).then(res => res.text());
     const loadedCheerio = parseHTML(body);
 
-    return this.parseNovels(loadedCheerio, searchTerm);
+    return this.parseNovelList(loadedCheerio, searchTerm);
   }
 }
 

--- a/plugins/english/faqwikius.ts
+++ b/plugins/english/faqwikius.ts
@@ -10,9 +10,7 @@ class FaqWikiUs implements Plugin.PluginBase {
   version = '3.0.1';
   icon = 'src/en/faqwikius/icon.png';
 
-  // Parses a list of NovelItem objects from already-loaded Cheerio HTML.
-  // "List" clarifies it returns NovelItem[] (used by popularNovels and searchNovels).
-  parseNovelList(loadedCheerio: CheerioAPI, searchTerm?: string) {
+  parseNovels(loadedCheerio: CheerioAPI, searchTerm?: string) {
     let novels: Plugin.NovelItem[] = [];
 
     loadedCheerio('.plt-page-item').each((index, element) => {
@@ -53,12 +51,10 @@ class FaqWikiUs implements Plugin.PluginBase {
     const body = await fetchApi(this.site).then(res => res.text());
     const loadedCheerio = parseHTML(body);
 
-    return this.parseNovelList(loadedCheerio);
+    return this.parseNovels(loadedCheerio);
   }
 
-  // Fetches and parses a single novel's full details page (metadata, chapters, status).
-  // "Details" distinguishes it from the list parser above.
-  async parseNovelDetails(path: string): Promise<Plugin.SourceNovel> {
+  async parseNovel(path: string): Promise<Plugin.SourceNovel> {
     const body = await fetchApi(this.site + path).then(res => res.text());
     const loadedCheerio = parseHTML(body);
     loadedCheerio('script').remove();
@@ -186,7 +182,7 @@ class FaqWikiUs implements Plugin.PluginBase {
     const body = await fetchApi(this.site).then(res => res.text());
     const loadedCheerio = parseHTML(body);
 
-    return this.parseNovelList(loadedCheerio, searchTerm);
+    return this.parseNovels(loadedCheerio, searchTerm);
   }
 }
 


### PR DESCRIPTION
#### Checklist

- [ x ] Update version code if an existing plugin was modified
- [ x ] Test changes in Plugin Playground or the app
- [ x ] Reference related issues in the PR body (e.g. Closes #xyz)

- Changed the `site` property in the `FaqWikiUs` plugin to point to the new URL (`https://faqwiki.us/novel`) and updated the `version` to `3.0.1` to match the latest site changes.