### PR TITLE
fix(novelbin): fix missing summary and remove NB Reader advertisements

### DIFF
--- a/plugins/multisrc/readnovelfull/sources.json
+++ b/plugins/multisrc/readnovelfull/sources.json
@@ -73,7 +73,8 @@
     "sourceName": "Novel Bin",
     "options": {
       "latestPage": "sort/latest",
-      "searchPage": "search"
+      "searchPage": "search",
+      "versionIncrements": 1
     }
   },
   {

--- a/plugins/multisrc/readnovelfull/sources.json
+++ b/plugins/multisrc/readnovelfull/sources.json
@@ -73,7 +73,8 @@
     "sourceName": "Novel Bin",
     "options": {
       "latestPage": "sort/latest",
-      "searchPage": "search"
+      "searchPage": "search",
+      "customJs": "$('[class*=\"app-promo\"]').remove();"
     }
   },
   {

--- a/plugins/multisrc/readnovelfull/template.ts
+++ b/plugins/multisrc/readnovelfull/template.ts
@@ -263,6 +263,7 @@ export class ReadNovelFullPlugin implements Plugin.PluginBase {
                 return;
               case 'inner':
               case 'desc-text':
+              case 'desc-text desc-text-collapsed':
                 if (state === ParsingState.Cover) popState();
                 pushState(ParsingState.Summary);
                 break;


### PR DESCRIPTION
This PR resolves two issues with the NovelBin plugin:
1. Fixes the empty novel summary/description caused by the multiple class names on the description wrapper `div` (`desc-text desc-text-collapsed`).
2. Adds a customJs script to automatically strip the "NB Reader" mobile app promotion/advertisements from chapter contents.

### Changes:
- Added case for `'desc-text desc-text-collapsed'` in the `parseNovel` method of the `readnovelfull` multisrc template.
- Configured a simplified `customJs` option for `novelbin` inside `sources.json` to remove elements with classes matching `app-promo`.
- Bumped NovelBin version increment (`versionIncrements: 1`).