### PR TITLE
fix chapter filter

### DIFF
--- a/plugins/english/lightnovelworld.ts
+++ b/plugins/english/lightnovelworld.ts
@@ -23,7 +23,7 @@ export class LightNovelWorldPlugin implements Plugin.PluginBase {
     name = "LightNovelWorld";
     icon = "src/en/lightnovelworld/icon.png";
     site = "https://lightnovelworld.org/";
-    version = "1.0.0";
+    version = "1.0.1";
 
     filters = {
         sort: {
@@ -132,7 +132,7 @@ export class LightNovelWorldPlugin implements Plugin.PluginBase {
                 { label: 'All', value: 'all' },
                 { label: '<50', value: '<50' },
                 { label: '50-100', value: '50-100' },
-                { label: '100-500', value: '500-1000' },
+                { label: '100-500', value: '100-500' },
                 { label: '500-1000', value: '500-1000' },
                 { label: '>1000', value: '>1000' },
             ],


### PR DESCRIPTION
The '100-500' Chapter Count option sent '500-1000' (copy-paste of the next option), so the two ranges were identical. Fixes the value; version bumped to 1.0.1.