### PR TITLE
fix(novelfrance): prevent skipping first paragraph in chapter parsing

### DIFF
--- a/plugins/french/novelfrance.ts
+++ b/plugins/french/novelfrance.ts
@@ -59,7 +59,7 @@ class NovelFrancePlugin implements Plugin.PluginBase {
   name = 'NovelFrance';
   icon = 'src/fr/novelfrance/icon.png';
   site = 'https://novelfrance.fr/';
-  version = '1.0.0';
+  version = '1.0.1';
 
   private async fetchJson<T>(url: string): Promise<T> {
     const r = await fetchApi(url);
@@ -205,9 +205,14 @@ class NovelFrancePlugin implements Plugin.PluginBase {
     if (title) parts.push(`<h1>${this.escapeHtml(title)}</h1>`);
 
     for (const p of data.paragraphs || []) {
-      if (title && p.index === 0) continue;
       const content = (p.content || '').trim();
       if (!content) continue;
+
+      // Si le paragraphe d'index 0 est une répétition exacte du titre du chapitre, on l'ignore
+      if (title && p.index === 0 && content.toLowerCase() === title.trim().toLowerCase()) {
+        continue;
+      }
+
       parts.push(`<p>${this.escapeHtml(content)}</p>`);
     }
 


### PR DESCRIPTION
#### Checklist

- [ ] Update version code if an existing plugin was modified
- [ ] Test changes in Plugin Playground or the app
- [ ] Reference related issues in the PR body (e.g. Closes #xyz)
- [ ] Le plugin supprimait systématiquement le paragraphe d'index 0 (p.index === 0), ce qui causait la perte du tout premier paragraphe du chapitre.
Solution apportée :
Modification de la condition dans parseChapter pour ne sauter le paragraphe d'index 0 que s'il est rigoureusement identique au titre du chapitre.
