### PR TITLE
fix(english/novel7s): fix paragraph parser for smart quotes

### DIFF
--- a/plugins/english/novel7s.ts
+++ b/plugins/english/novel7s.ts
@@ -74,7 +74,7 @@ class Novel7sPlugin implements Plugin.PluginBase {
   icon = 'src/en/novel7s/icon.png';
   site = 'https://novel7s.com';
   rest = `${this.site}/wp-json/wp/v2`;
-  version = '1.0.0';
+  version = '1.0.1';
 
   filters = {
     sort: {

--- a/plugins/english/novel7s.ts
+++ b/plugins/english/novel7s.ts
@@ -235,7 +235,7 @@ class Novel7sPlugin implements Plugin.PluginBase {
       if (!text) continue;
 
       // If it ends like a complete sentence, keep separate
-      if (/[.!?…]["'"']?$/.test(text)) continue;
+      if (/[.!?…]["'”’»]?$/.test(text)) continue;
 
       $(current).append(' ');
       $(current).append($(next).contents());


### PR DESCRIPTION
## **fix(english/novel7s): fix paragraph parser for smart quotes**
- Fixed an issue where the paragraph parser would incorrectly merge paragraphs if a sentence ended with a smart quote (`”` or `’`).
- Bumped plugin version to `1.0.1`.

#### Checklist

- [x] Update version code if an existing plugin was modified
- [x] Test changes in Plugin Playground or the app
- [x] Reference related issues in the PR body (e.g. Closes #xyz)