### PR TITLE
chore: add disclaimer note to plugin request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/request_plugin.yml
@@ -2,6 +2,11 @@ name: Request Plugin
 description: Request a new plugin for LNReader
 labels: [Plugin Request]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Note:** Creating a plugin request does not guarantee it will be added. Please wait for a maintainer or contributor to pick it up — or, since this is open source, feel free to contribute the plugin yourself!
+
   - type: input
     id: name
     attributes:


### PR DESCRIPTION
#### Checklist

- [x] N/A — this changes the issue template, not a plugin
- [x] N/A — no app changes to test
- [x] N/A — no related issue to reference

## Summary

Adds a note at the top of the "Request Plugin" issue template clarifying that filing a request doesn't guarantee it will be built, and pointing requesters toward contributing the plugin themselves since this is open source.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EcVn7ebyh5i4W6BnSVvWMA)_