### PR TITLE
fix(lightnovelwp): mark Baca Light Novel as down (#2457)

### DIFF
--- a/plugins/multisrc/lightnovelwp/sources.json
+++ b/plugins/multisrc/lightnovelwp/sources.json
@@ -44,7 +44,9 @@
     "sourceName": "Baca Light Novel",
     "options": {
       "lang": "Indonesian",
-      "reverseChapters": true
+      "reverseChapters": true,
+      "down": true,
+      "downSince": 1787666612560
     }
   },
   {


### PR DESCRIPTION
Closes #2457

## What

Marks the `bacalightnovel` source down in `plugins/multisrc/lightnovelwp/sources.json`, following the exact convention of the seven already-marked-down sources in this file (`allnovelread`, `pandamtl`, `moonlightnovel`, `ellotl`, `cpunovel`, `keopi`, `betternovels`), introduced upstream by #1978:

```json
"options": {
  "lang": "Indonesian",
  "reverseChapters": true,
  "down": true,
  "downSince": 1787666612560
}
```

Two lines added, nothing else touched.

## Evidence the site is unreachable

Measured 2026-08-25:

- Direct requests meet a Cloudflare bot challenge: HTTP 403 with a `Cf-Mitigated: challenge` header on `/`, `/series/?page=1`, `/wp-json/`, and the www host.
- Challenge-exempt relays that get past the wall (api.codetabs.com, api.allorigins.win) receive Cloudflare error 522 (origin connection timed out) on both `/` and a real chapter URL, repeated over roughly 10 minutes.
- This repo's own checker agrees: `node scripts/live-check-plugin.js 'plugins/indonesian/BacaLightNovel[lightnovelwp].ts'` reports `siteReachability: INCONCLUSIVE HTTP 403 (Cloudflare)`.

Requests therefore die at the network layer before any parsing: the plugin's fetch wrapper throws and readers see an error or empty chapters, matching the report.

## Why flag instead of remove

Keeping the entry preserves users' libraries and bookmarks, and if the site comes back, re-enabling it is a one-line revert of this flag. That is exactly how the seven confirmed-dead sources above are already handled per #1978.

## Honest limitation

Today's live HTML could not be fetched from the host that ran the diagnosis (Cloudflare challenge for direct clients, 522 through relays), so dead origin is inferred from consistent 522 responses past the edge plus the reporter's error symptoms, not proven by capturing today's failing page. The plugin's parser and selectors were verified against real archived site markup (Wayback capture of a chapter page from 2025-07-10; replaying the template's parse extracted over 20,000 characters of chapter text), so no selector or domain change is included. If anyone can load bacalightnovel.co in a normal browser right now, please comment and this should be re-verified before merging anything beyond the flag.

## Note on who consumes the flag

`grep -rn '"down"' scripts/build-plugin-manifest.js src/` currently returns nothing: neither the manifest builder nor app code consumes `down` yet. The flag follows house precedent (#1978) and costs nothing until tooling starts reading it.

## Verification done on this branch

- `plugins/multisrc/lightnovelwp/sources.json` parses as valid JSON after the change.
- `node ./plugins/multisrc/generate-multisrc-plugins.js` runs clean, and the regenerated `BacaLightNovel[lightnovelwp].ts` embeds `"down":true,"downSince":1787666612560`, exactly like the generated files of the existing down sources.
- Live check remains at its pre-change baseline: INCONCLUSIVE HTTP 403 (Cloudflare).
