### PR TITLE
fix(build): keep tests/*.mjs out of tsc input; cover *.mjs in lint/format

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -165,7 +165,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['**/*.{ts,tsx,mts,cts,js,cjs}'],
+    files: ['**/*.{ts,tsx,mts,cts,js,cjs,mjs,mjsx}'],
     ignores: ['./plugins/*/*.ts', './plugins/multisrc/*/template.ts'],
     rules: {
       'no-unused-vars': 'off',

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "serve:dev": "npm run build:compile && npm run build:manifest:dev && serve",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix",
-    "format": "prettier --write \"./**/*.{js,ts}\"",
-    "format:check": "prettier --check \"./**/*.{js,ts}\"",
+    "format": "prettier --write \"./**/*.{js,mjs,ts}\"",
+    "format:check": "prettier --check \"./**/*.{js,mjs,ts}\"",
     "check:sites": "node scripts/check-plugin-sites.js",
     "check:plugin": "node scripts/live-check-plugin.js",
     "prepare": "husky"
@@ -95,6 +95,6 @@
     "zustand": "^5.0.1"
   },
   "lint-staged": {
-    "**/*.{js,ts,jsx,tsx}": "prettier --write"
+    "**/*.{js,mjs,ts,jsx,tsx}": "prettier --write"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -122,6 +122,7 @@
     "./plugins/**/*.broken.ts",
     "./.js/**/*",
     "scripts/**",
+    "./tests/**",
     "docs/**",
     "public/**",
     ".github/**",

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -115,6 +115,7 @@
     "./plugins/**/*.broken.ts",
     "./.js/**/*",
     "scripts/**",
+    "./tests/**",
     "docs/**",
     "./src/*.*",
     "./*.*",


### PR DESCRIPTION
## What

With a plain-node regression script present under `tests/`, building with

    npx tsc --project tsconfig.production.json && node scripts/build-plugin-manifest.js

produces an EMPTY plugin manifest: `.dist/plugins.json` reports `| Total | 0 (0) |`, so any downstream "plugin X absent" assertion passes vacuously.

## Why / how

- `tsconfig.production.json` sets `allowJs: true`, defines no `rootDir`, and its `exclude` array lists neither `tests/**` nor any `.mjs` pattern.
- A `tests/regression-*.mjs` file therefore enters the tsc program; the inferred rootDir becomes the repo root; emit lands nested at `.js/plugins/plugins/<lang>/<file>.js` plus `.js/plugins/tests/regression-N.mjs`.
- `scripts/build-plugin-manifest.js` scans `./.js/plugins/<lang>/`, finds nothing, and writes `[]`.

Fix (4 files, +6/-4):

1. `tsconfig.json` and `tsconfig.production.json`: insert `"./tests/**"` into `exclude`, right after the existing `"scripts/**"` entry (same convention: tooling that plain node runs, tsc ignores).
2. `eslint.config.js`: extend the project-rules files glob from `{ts,tsx,mts,cts,js,cjs}` to `{ts,tsx,mts,cts,js,cjs,mjs,mjsx}`; that config object already registers node globals, which the `.mjs` scripts need.
3. `package.json`: add `mjs` to the `format` / `format:check` globs and to lint-staged.

No rootDir change, no emit-layout reshaping, no manifest-script edit.

## Tests

Executed locally on 2026-08-25 at base `e1dcd06` (RED baseline) and at this branch head (GREEN); tsc 5.9.3, node v26.5.1.

| Gate | Base (no fix) | This branch |
|---|---|---|
| tsc -p tsconfig.production.json | exit 0 but nested emit: `.js/plugins/plugins/{arabic..vietnamese}` and `.js/plugins/tests/regression-2453.mjs`; manifest `\| Total \| 0 (0) \|` (RED) | exit 0; no `.js/plugins/plugins`, no `.js/tests`; manifest `\| Total \| 117 (68) \|` |
| Placement equivalence: `tests/` moved out of tree, fresh rebuild | n/a | identical `\| Total \| 117 (68) \|` (tsc input scope no longer depends on test placement) |
| eslint on `tests/**/*.mjs` + `eslint.config.js` | 3 false `no-undef` errors on `regression-2453.mjs` (`console` x2, `process`) | exit 0 |
| prettier --check on `package.json`, `eslint.config.js`, `tsconfig.production.json`, `tests/*.mjs` | - | all clean (`tsconfig.json` keeps pre-existing upstream style debt, deliberately untouched) |
| regression harness run | byte-identical stdout and exit code before vs after (its own PASS/FAIL verdict belongs to #2453/#2468) | |

Context for the totals (2026-08-25): #2468 (RanobeHub retirement) is OPEN, so `117 (68)` is correct against current master; once it merges, the expected total becomes `116 (67)`. #2466 (Riwyat) is OPEN too; if it lands first, its eslint config object and this glob extension are separate hunks that compose cleanly.

## Gates

- Branch diff vs `e1dcd06`: exactly 4 files changed, +6/-4, nothing else; no lockfile churn; no CI workflow edits.
- `.github/workflows/publish-plugins.yml` untouched.

Closes: none (repo-level build defect, no upstream issue).

Automated contribution via Hermes Agent.
