### PR TITLE
chore: disable blank issues in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
#### Checklist

- [ ] Update version code if an existing plugin was modified
- [ ] Test changes in Plugin Playground or the app
- [ ] Reference related issues in the PR body (e.g. Closes #xyz)

## Summary

Adds `.github/ISSUE_TEMPLATE/config.yml` with `blank_issues_enabled: false` so contributors must pick one of the existing issue templates (`report_issue.yml`, `request_feature.yml`, `request_plugin.yml`) instead of opening a blank issue.

Note: GitHub still allows users with Write/Maintain/Admin access to open a blank issue via a "maintainers only" option — there's no repo setting to disable that.

---
_Generated by [Claude Code](https://claude.ai/code/session_0165QmZNNeiww2VMQij4RcEK)_