### PR TITLE
fix: mark novelsparadise as down due to Cloudflare challenge

### DIFF
--- a/plugins/multisrc/lightnovelwp/sources.json
+++ b/plugins/multisrc/lightnovelwp/sources.json
@@ -73,7 +73,9 @@
     "sourceName": "Novels Paradise",
     "options": {
       "lang": "Arabic",
-      "reverseChapters": true
+      "reverseChapters": true,
+      "down": true,
+      "downSince": 1756224000000
     }
   },
   {


### PR DESCRIPTION
## Problem

Chapter pages on `novelsparadise.site` are now blocked by Cloudflare JavaScript challenge ("Just a moment..."), preventing automated fetching via `fetch()`.

## Changes

- Added `"down": true` and `"downSince"` to the novelsparadise entry in `sources.json`
- This informs LNReader users that the source is temporarily unavailable

## Details

- ✅ Series listing page (`/series/`) works fine
- ✅ Search works fine  
- ✅ Novel detail page works fine
- ❌ Chapter pages return Cloudflare challenge page

The source will need to be unmarked once either:
1. The site owner removes Cloudflare protection from chapter pages
2. LNReader adds WebView-based chapter loading to bypass the challenge

## Testing

Verified that listing, search, and novel pages return valid HTML. Only chapter pages are blocked by Cloudflare.