### PR TITLE
docs: add commit message conventions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,4 @@
 - [ ] Update version code if an existing plugin was modified
 - [ ] Test changes in Plugin Playground or the app
 - [ ] Reference related issues in the PR body (e.g. Closes #xyz)
-- [ ] Commit messages follow `type(scope): description` (e.g. `feat(madara): add new source`)
+- [ ] Commit messages follow `type(scope): description` (e.g. `feat(<generator>): add new source`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,3 +3,4 @@
 - [ ] Update version code if an existing plugin was modified
 - [ ] Test changes in Plugin Playground or the app
 - [ ] Reference related issues in the PR body (e.g. Closes #xyz)
+- [ ] Commit messages follow `type(scope): description` (e.g. `feat(madara): add new source`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,3 +140,7 @@ Use Conventional Commits: `type(scope): description`
 Examples:
 - feat(<generator>): add new source
 - fix(<language>/<plugin>): correct chapter list parsing
+
+If a commit or PR was authored (fully or partly) by an AI agent, note that in the commit message
+(e.g. a `Co-Authored-By:` trailer) or the PR description so reviewers know to weight their review
+accordingly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,3 +128,15 @@ works because target-site markup and network defenses change independently of th
   `Closes #123`).
 - Before handing off an existing-plugin change, confirm that its version was incremented and report
   any live checks that were inconclusive because of network or anti-bot behavior.
+
+## Commit messages
+
+Use Conventional Commits: `type(scope): description`
+
+- type: feat (new plugin), fix (bug fix), perf, chore, docs, refactor
+- scope: language/plugin folder, e.g. `madara`, `english/novel7s`, `ar/rewayahfans`
+- Lowercase type, imperative mood ("add" not "added"/"adds")
+
+Examples:
+- feat(madara): add new source
+- fix(lnori): correct chapter list parsing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,9 +134,9 @@ works because target-site markup and network defenses change independently of th
 Use Conventional Commits: `type(scope): description`
 
 - type: feat (new plugin), fix (bug fix), perf, chore, docs, refactor
-- scope: language/plugin folder, e.g. `madara`, `english/novel7s`, `ar/rewayahfans`
+- scope: language/plugin folder, e.g. `<language>`, `<language>/<plugin>`
 - Lowercase type, imperative mood ("add" not "added"/"adds")
 
 Examples:
-- feat(madara): add new source
-- fix(lnori): correct chapter list parsing
+- feat(<generator>): add new source
+- fix(<language>/<plugin>): correct chapter list parsing


### PR DESCRIPTION
## Summary

- Add a "Commit messages" section to `AGENTS.md` documenting the Conventional Commits format (`type(scope): description`) with generic (non-plugin-specific) examples.
- Add a new PR checklist item in `.github/pull_request_template.md` to remind contributors that commit messages should follow this convention.

#### Checklist

- [ ] Update version code if an existing plugin was modified — N/A, no plugin code changed
- [ ] Test changes in Plugin Playground or the app — N/A, documentation-only change
- [ ] Reference related issues in the PR body (e.g. Closes #xyz) — none
- [ ] Commit messages follow `type(scope): description` (e.g. `feat(<generator>): add new source`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013g3Dp3WPhaGsTEMrAa2szW)_