### PR TITLE
chore(french): novhell drop Accept-Encoding override

### DIFF
--- a/plugins/french/novhell.ts
+++ b/plugins/french/novhell.ts
@@ -36,14 +36,15 @@ class NovhellPlugin implements Plugin.PluginBase {
   name = 'Novhell';
   icon = 'src/fr/novhell/icon.png';
   site = 'https://novhell.org';
-  version = '1.0.4';
+  version = '1.0.5';
 
   async getCheerio(url: string): Promise<CheerioAPI> {
-    return load(
-      await fetchCheckedHtml(url, {
-        headers: { 'Accept-Encoding': 'deflate' },
-      }),
-    );
+    // Do not override Accept-Encoding: the app already sends
+    // `gzip, deflate` with its Android User-Agent. Forcing `deflate`
+    // alone disables transparent decompression on Android (OkHttp):
+    // the HTML arrives compressed, cheerio finds nothing (0 chapters),
+    // while the webview (a real browser) renders everything.
+    return load(await fetchCheckedHtml(url));
   }
 
   async popularNovels(pageNo: number): Promise<Plugin.NovelItem[]> {


### PR DESCRIPTION
#### Checklist

- [x] Update version code if an existing plugin was modified (1.0.4 -> 1.0.5)
- [x] Test changes in Plugin Playground or the app (live-check + on-device below)
- [x] Commit messages follow type(scope): description

#### Context

Reported symptom: opening a Novhell novel in the app shows no chapters, while the WebView renders fine. I investigated but could **not** reproduce it:

- Emulator + app v2.1.0 + plugin v1.0.4 (official code): Tempest of the Stellar War opens with **393 chapters**.
- \
ode scripts/live-check-plugin.js\-equivalent harness: all PASS (5 novels, 393 chapters, chapter body 15805 chars); all 5 novels parse (244-452 chapters) and sampled first/middle/last chapters return 11k-28k chars.
- Cloudflare answers plain HTML (identity) to \Accept-Encoding: deflate\ even with the exact app headers over HTTP/1.1 and HTTP/2, so the override is harmless on the tested path.

So this PR does **not** claim to fix that report - the cause is still unknown (possibly IP-based bot challenge on the reporter's network, or a stale installed plugin).

#### What this PR does

Removes the anomalous \Accept-Encoding: deflate\ override from \getCheerio\ so the app default headers (\gzip, deflate\ + Android User-Agent, see \src/plugins/helpers/fetch.ts\) apply - the same as every other non-French plugin in the repo. A manually-set \Accept-Encoding\ disables transparent response decompression on Android (OkHttp), so the override is a latent 0-chapter risk with zero benefit.

#### Tests

- Live-check harness with the default-header path: all PASS (popular 5, search 1, parseNovel 393 chapters, parseChapter 15805 chars).
- On-device (emulator, app v2.1.0): updated installed plugin 1.0.4 -> 1.0.5 via local repository manifest, reopened the novel - still 393 chapters, no regression.
- \	sc\ (ES5 production config) and eslint pass.