### PR TITLE
fix(french): novhell chapters using Gutenberg template

### DIFF
--- a/plugins/french/novhell.ts
+++ b/plugins/french/novhell.ts
@@ -36,7 +36,7 @@ class NovhellPlugin implements Plugin.PluginBase {
   name = 'Novhell';
   icon = 'src/fr/novhell/icon.png';
   site = 'https://novhell.org';
-  version = '1.0.4';
+  version = '1.0.5';
 
   async getCheerio(url: string): Promise<CheerioAPI> {
     return load(
@@ -208,6 +208,34 @@ class NovhellPlugin implements Plugin.PluginBase {
         )
           return content;
       }
+    }
+    // Newer chapters use a Gutenberg block template with no `section`
+    // elements: title in the columns block holding the `h4`, body in the
+    // longest columns block of `article .entry-content`.
+    const entry = $('article .entry-content').first();
+    if (entry.length) {
+      let titleHtml = '';
+      let bodyHtml = '';
+      let bodyLength = 0;
+      entry.children('div.wp-block-columns').each((_, element) => {
+        const block = $(element);
+        if (block.find('h4').length) {
+          if (!titleHtml) titleHtml = $.html(element) || '';
+          return;
+        }
+        const textLength = block.text().replace(/\s+/g, ' ').trim().length;
+        if (textLength > bodyLength) {
+          bodyLength = textLength;
+          bodyHtml = $.html(element) || '';
+        }
+      });
+      const content = titleHtml + bodyHtml;
+      const parsedContent = load(content);
+      if (
+        parsedContent.text().replace(/\s+/g, ' ').trim().length >= 200 ||
+        parsedContent('img').length
+      )
+        return content;
     }
     throw new Error('No readable chapter content found');
   }


### PR DESCRIPTION
#### Checklist

- [x] Update version code if an existing plugin was modified (1.0.4 -> 1.0.5)
- [x] Test changes in Plugin Playground or the app (see Tests)
- [x] Commit messages follow type(scope): description

#### Bug

Opening some Tempest of the Stellar War chapters (e.g. 251, 252) fails with \No readable chapter content found\, while the same pages render fine in the WebView.

#### Root cause

Those chapter pages use a WordPress Gutenberg block template (\rticle .entry-content\ with \.wp-block-columns\ children, zero \section\ elements) instead of the classic \main article div div section\ layout. \parseChapter\ only handled the classic layout, found no sections, and threw. Classic chapter pages (e.g. ch. 250: 5 sections, title \h4\ + body) are unaffected.

#### Fix

- \plugins/french/novhell.ts\: keep the classic section heuristic first (unchanged); on miss, fall back to the Gutenberg layout - title from the columns block holding the \h4\, body from the longest columns block - with the same >=200-chars-or-image validation.

#### Tests

- Before: \/tsw-chapitre-251/\ and \/tsw-chapitre-252/\ threw \No readable chapter content found\.
- After: 251 OK (14990 chars, starts with chapter title), 252 OK (10179 chars); classic chapters byte-identical results (250, tsw-1, sws-1 verified).
- Full audit of all 5 novels (1758 chapters): zero parse failures remaining. The only 4 errors are site-side HTTP 404s on typo'd links the plugin cannot fix: \	sw-chapitre-1781\, \jtsw-chapitre-386\ (should be \	sw-\), \	tob-chapitre-58\ (should be \	otb-\), \srh-chapitre-360-2\ (wrong-novel prefix inside Swallowed Star).
- Live-check harness: all PASS (popular 5, search 1, parseNovel 393 chapters, parseChapter 15805 chars); eslint and ES5 production \	sc\ clean.