### PR TITLE
fix(english/mvlempyr): return contract-conformant novel items

### DIFF
--- a/plugins/english/mvlempyr.ts
+++ b/plugins/english/mvlempyr.ts
@@ -30,7 +30,7 @@ class MVLEMPYRPlugin implements Plugin.PluginBase {
   name = 'MVLEMPYR';
   icon = 'src/en/mvlempyr/icon.png';
   site = 'https://www.mvlempyr.io/';
-  version = '1.0.12';
+  version = '1.0.13';
 
   _chapSite = 'https://chap.heliosarchive.online/';
   _allNovels: (Plugin.NovelItem & ExtraNovelData)[] | undefined;
@@ -81,7 +81,11 @@ class MVLEMPYRPlugin implements Plugin.PluginBase {
     // @ts-ignore
     const sorted = filtered.sort((a, b) => b[sortKey] - a[sortKey]);
 
-    return this.paginate(sorted, pageNo);
+    return this.paginate(sorted, pageNo).map(({ name, path, cover }) => ({
+      name,
+      path,
+      cover,
+    }));
   }
 
   convertNovelId(e: bigint) {
@@ -186,7 +190,11 @@ class MVLEMPYRPlugin implements Plugin.PluginBase {
       novel.name.toLowerCase().includes(searchTerm.toLowerCase()),
     );
 
-    return this.paginate(searchResults, page);
+    return this.paginate(searchResults, page).map(({ name, path, cover }) => ({
+      name,
+      path,
+      cover,
+    }));
   }
 
   paginate<T>(data: T[], page: number): T[] {


### PR DESCRIPTION
### Problem

Opening any MVLEMPYR novel from browse or search crashes the novel screen on LNReader v2.1.0 (the current `Latest` release) with:

```
TypeError: undefined is not a function
  at anonymous
  at renderWithHooks
  at updateSimpleMemoComponent
  at updateMemoComponent
```

Refs #2437 (same versions: app 2.1.0, plugin 1.0.12).

### Root cause

`popularNovels` and `searchNovels` return the raw cached objects from `getAllNovels()` straight through `paginate()`, so the internal `ExtraNovelData` fields ride along on what is typed as a `Plugin.NovelItem`:

```json
{ "name": "...", "path": "...", "cover": "...",
  "genres": ["Horror", "Mature"], "tags": [...], "avgReview": 5, "created": 1745549652956 }
```

`NovelItem` is `{name, path, cover?}`, and `genres` is only valid on `SourceNovel`, where it is documented as a comma-separated **string**. `parseNovel` returns it correctly as a string; the browse/search list did not.

Before app v2.1.2, `NovelGenres` called `genres.split(/,\s*/)` inside a `useMemo` without validating the type. A novel opened from browse renders that header from the list item — with the array — before `parseNovel` resolves. `Array.prototype.split` does not exist, so calling it throws `undefined is not a function`, which matches the reported stack exactly.

App-side this was guarded in LNReader `eb12bdf` ("Prevent Novel Genre Rendering Crashes", shipped in v2.1.2), but v2.1.2 and v2.1.3 are both pre-releases — everyone on stable v2.1.0 still hits it. Plugins update independently of the app, so fixing it here reaches those users without an app update.

### Fix

Map both return sites down to `{name, path, cover}`. Filtering and sorting still run on the full objects beforehand, and `getAllNovels()`'s cache is untouched, so the filter/order behaviour is unchanged.

Version bumped `1.0.12` → `1.0.13` (patch — compatibility fix).

### Verification

- `npm run check:plugin -- plugins/english/mvlempyr.ts` → 4/4 PASS (`popularNovels` 20 novels, `searchNovels` 6 results, `parseNovel` 1432 chapters, `parseChapter` 9044 chars)
- `npx eslint` clean, `npx tsc --noEmit --project tsconfig.production.json` clean
- Asserted against the live site that `popularNovels` and `searchNovels` now return exactly `{cover, name, path}`, and that `parseNovel().genres` is still a string (`"Horror,Mature,Mystery,Psychological,Supernatural"`)

### Checklist

- [x] Update version code if an existing plugin was modified
- [x] Test changes in Plugin Playground or the app
- [x] Reference related issues in the PR body (e.g. Closes #xyz)
- [x] Commit messages follow `type(scope): description`

### Note

Per `AGENTS.md`, disclosing that this change was prepared with AI assistance so reviewers can weight their review accordingly.